### PR TITLE
Add comprehensive CITATION files

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,25 @@
+PKG <- "tyler"
+
+citHeader(paste("To cite the R package", PKG, "in publications use:"))
+
+if(!exists("meta") || is.null(meta)) meta <- packageDescription(PKG)
+stopifnot(meta$Package == PKG)
+
+year <- sub(".*(2[[:digit:]]{3}).*", "\\1", meta$Date)
+vers <- paste("R package version", meta$Version)
+url <- "https://mufflyt.github.io/tyler/"
+
+bibentry(bibtype = "Manual",
+         title  = meta$Title,
+         author = person("Tyler", "Muffly",
+                        email = "tyler.muffly@dhha.org",
+                        role = c("aut", "cre"),
+                        comment = c(ORCID = "0000-0002-2044-1693")),
+         year   = year,
+         note   = vers,
+         url    = url,
+         textVersion = paste("Tyler Muffly (", year, ").",
+                            meta$Title, ".", vers, ".",
+                            "Available at", url))
+
+citFooter("Please see the package website for more details and updates.")

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "tyler: Common Functions for Mystery Caller or Audit Studies Evaluating Patient Access to Care"
+version: "1.2.0"
+date-released: "2023-09-11"
+authors:
+  - family-names: "Muffly"
+    given-names: "Tyler"
+    email: "tyler.muffly@dhha.org"
+    orcid: "https://orcid.org/0000-0002-2044-1693"
+license: "MIT"
+repository-code: "https://github.com/mufflyt/tyler"
+url: "https://mufflyt.github.io/tyler/"
+keywords:
+  - R
+  - healthcare
+  - audit study
+  - NPI
+  - mystery caller
+description: |
+  The 'tyler' package provides a collection of functions designed to facilitate mystery caller
+  studies and other audit-style evaluations of patient access to healthcare. It streamlines
+  retrieval and analysis of National Provider Identifier (NPI) data and includes utilities for
+  generating tables and visualizations to aid in workforce research.


### PR DESCRIPTION
## Summary
- add an `inst/CITATION` entry for the tyler package
- provide metadata for GitHub via `CITATION.cff`

## Testing
- `R CMD build .` *(fails: dependencies not available)*

------
https://chatgpt.com/codex/tasks/task_e_68601a83a844832c91c463fd733f19e9