### PR TITLE
Update .Rbuildignore to skip data files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,18 @@
 ^doc$
 ^Meta$
 ^codecov\.yml$
+
+^\.cache$
+^inst/extdata/hsa-shapefile$
+^inst/extdata/hrr-shapefile$
+
+# Misc build artifacts and temp files
+^cran-comments\.md$
+^inst/doc$
+\.DS_Store$
+.*\.Rhistory$
+.*\.RData$
+
+# Ignore data files
+.*\.rds$
+.*\.csv$


### PR DESCRIPTION
## Summary
- exclude rds and csv files from the package build
- ignore large shapefile directories and cache
- add patterns for common build artifacts like cran-comments.md and inst/doc

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603a46cc50832c945f7faed9f94298