### PR TITLE
Use projected CRS for intersection areas

### DIFF
--- a/man/calculate_intersection_overlap_and_save.Rd
+++ b/man/calculate_intersection_overlap_and_save.Rd
@@ -24,7 +24,7 @@ calculate_intersection_overlap_and_save(
 None. The function saves the intersection shapefile and provides logging.
 }
 \description{
-This function calculates the intersection between block groups and isochrones for a specific drive time and saves the results to a shapefile.
+This function calculates the intersection between block groups and isochrones for a specific drive time and saves the results to a shapefile.  Areas are measured after reprojecting both datasets to an equal-area coordinate reference system for accuracy.
 }
 \examples{
 calculate_intersection_overlap_and_save(block_groups, isochrones_joined, 30L, "data/shp/")


### PR DESCRIPTION
## Summary
- reproject block groups and isochrones to EPSG 5070 for area calculations
- update docs for `calculate_intersection_overlap_and_save`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6860390bdf24832cbdcea42ac117eec8