### PR TITLE
Automated pkgdown deploy after checks

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,13 +1,10 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-  release:
-    types: [published]
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["R-CMD-check"]
+    types:
+      - completed
 
 name: pkgdown
 
@@ -15,6 +12,7 @@ permissions: read-all
 
 jobs:
   pkgdown:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:
@@ -25,6 +23,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Configure git for deployment
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -42,7 +45,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false


### PR DESCRIPTION
## Summary
- trigger pkgdown workflow when R‑CMD check succeeds
- ensure safe git configuration
- deploy website to `gh-pages`

## Testing
- `R CMD build . --no-build-vignettes --no-manual`
- `R CMD check tyler_1.2.1.tar.gz --no-tests --no-manual` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6860405e2800832c9afe257aec480d3a