### PR TITLE
Improve CRAN compliance

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,5 @@
 # Ignore data files
 .*\.rds$
 .*\.csv$
+^To_amany\.R$
+^install_log\.txt$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,6 @@ Imports:
     npi,
     openxlsx,
     progress,
-    provider,
     purrr,
     rainbow,
     readr,
@@ -76,7 +75,6 @@ Imports:
     viridis,
     webshot,
     zipcodeR
-Remotes: andrewallenbruce/provider, lmullen/genderdata
 LazyData: true
 Files: R/
 Suggests: 
@@ -84,6 +82,7 @@ Suggests:
     pkgdown,
     rmarkdown,
     stats,
+    provider,
     genderdata
 VignetteBuilder: knitr
 VignetteEngine: knitr::rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
 # tyler 0.0.0.9000
 
 * Added a `NEWS.md` file to track changes to the package.
+* Updated CRAN compliance:
+  * Moved `provider` to Suggests and added runtime checks.
+  * Removed automatic installation of `genderdata` and `provider` packages.
+  * Excluded `To_amany.R` and `install_log.txt` from the build.

--- a/R/genderize_physicians.R
+++ b/R/genderize_physicians.R
@@ -21,7 +21,11 @@
 #' @export
 genderize_physicians <- function(input_csv, output_dir = getwd()) {
   if (!requireNamespace("genderdata", quietly = TRUE)) {
-    remotes::install_github("lmullen/genderdata")
+    stop(
+      "Package 'genderdata' is required for this function. " ,
+      "Install it from GitHub with remotes::install_github('lmullen/genderdata').",
+      call. = FALSE
+    )
   }
   # Read the data
   gender_Physicians <- readr::read_csv(input_csv, show_col_types = FALSE)

--- a/R/get_clinician_data.R
+++ b/R/get_clinician_data.R
@@ -69,6 +69,13 @@ validate_and_remove_invalid_npi <- function(input_data) {
 #' @family npi
 #' @export
 retrieve_clinician_data <- function(input_data) {
+  if (!requireNamespace("provider", quietly = TRUE)) {
+    stop(
+      "Package 'provider' is required for this function. " ,
+      "Install it from GitHub with remotes::install_github('andrewallenbruce/provider').",
+      call. = FALSE
+    )
+  }
 
   if (is.data.frame(input_data)) {
     # Input is a dataframe


### PR DESCRIPTION
## Summary
- move `provider` to Suggests
- stop installing GitHub packages at run time
- ignore non-package scripts
- note compliance updates in NEWS

## Testing
- `R CMD build .` *(fails: dependencies ‘arsenal’, ‘censusapi’, ‘easyr’, ‘exploratory’, ‘gender’, ‘ggmap’, ‘ggspatial’, ‘hereR’, ‘humaniformat’, ‘imager’, ‘janitor’, ‘leaflet’, ‘leaflet.extras’, ‘npi’, ‘rainbow’, ‘rnaturalearth’, ‘tigris’, ‘tmap’, ‘zipcodeR’ are not available for package ‘tyler’)*

------
https://chatgpt.com/codex/tasks/task_e_68619dc48078832c92be4c225ae0df14