### PR TITLE
Fix DESCRIPTION author field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: tyler
 Title: Common Functions for Mystery Caller or Audit Studies Evaluating Patient Access to Care
 Version: 1.2.1
-Authors@R: 
+Author: Tyler Muffly [aut, cre]
+Authors@R:
     person("Tyler", "Muffly", email = "tyler.muffly@dhha.org", role = c("aut", "cre"),
            comment = "ORCID: 0000-0002-2044-1693")
 Description: Provides utilities for mystery caller and audit studies evaluating patient access to healthcare. Functions help search and process National Provider Identifier (NPI) records, summarize provider demographics, and generate tables and maps for analysis and reporting.


### PR DESCRIPTION
## Summary
- add missing `Author` field to DESCRIPTION to satisfy R CMD checks

## Testing
- `R CMD check --no-manual` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686473e58fb0832c95bcd0876051762d