### PR TITLE
Add pkgdown index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,16 @@
+---
+title: "tyler"
+---
+
+This site documents the **tyler** package. For installation instructions and an overview, see the [README](README.html).
+
+## Vignettes
+
+The following articles provide in depth examples and workflows:
+
+- [Create Isochrones](articles/create_isochrones.html)
+- [Get Census Data](articles/get_census_data.html)
+- [Geocoding Overview](articles/geocode.html)
+- [Search & Process NPI](articles/search_and_process_npi.html)
+- [Validate & Remove Invalid NPI](articles/validate_and_remove_invalid_npi.html)
+- [Aggregating Provider Data](articles/aggregating_provider_data.html)


### PR DESCRIPTION
## Summary
- add `index.md` linking README and vignettes for pkgdown site

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648dfd2abc832ca265be96eb6f2c6f