### PR TITLE
Add pkgdown deployment workflow

### DIFF
--- a/.github/workflows/pkgdown-deploy.yml
+++ b/.github/workflows/pkgdown-deploy.yml
@@ -1,0 +1,41 @@
+# Deploy pkgdown site to gh-pages branch
+name: pkgdown-deploy
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+      - name: Deploy to GitHub Pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build pkgdown site and deploy to `gh-pages`

## Testing
- `R CMD build .` *(fails: vignette builder 'knitr' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648e0de464832c916b74c136bc1ee8