### PR TITLE
Add lifecycle badges and tags

### DIFF
--- a/R/Splitting_dataframe_to_send_to_callers.R
+++ b/R/Splitting_dataframe_to_send_to_callers.R
@@ -2,6 +2,9 @@
 #'
 #' This function splits the data based on provided lab assistant names and saves each part as a separate Excel file.
 #' It allows the arrangement of calls by insurance type to prioritize Medicaid in the first two days and Blue Cross/Blue Shield in the last two days.
+#'
+#' @section Lifecycle:
+#' \lifecycle{stable}
 #' @name split_and_save
 #' @param data_or_path Either a dataframe containing the input data or a path to the input data file (RDS, CSV, or XLS/XLSX).
 #' @param output_directory Directory where output Excel files will be saved.

--- a/R/calculate_intersection_overlap_and_save.R
+++ b/R/calculate_intersection_overlap_and_save.R
@@ -4,6 +4,9 @@
 #' ensure accurate area-based calculations, both datasets are temporarily
 #' projected to an equal-area CRS before measuring.
 #'
+#' @section Lifecycle:
+#' \lifecycle{experimental}
+#' 
 #' @param block_groups An sf object representing block groups.
 #' @param isochrones_joined An sf object representing isochrones.
 #' @param drive_time The drive time value for which to calculate the intersection.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Codecov test coverage](https://codecov.io/gh/mufflyt/tyler/branch/master/graph/badge.svg)](https://app.codecov.io/gh/mufflyt/tyler?branch=master)
 [![CRAN status](https://www.r-pkg.org/badges/version/tyler)](https://CRAN.R-project.org/package=tyler)
 [![R-CMD-check](https://github.com/mufflyt/tyler/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/mufflyt/tyler/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
 The goal of the 'tyler' package provides a collection of functions designed to facilitate mystery caller studies, often used in evaluating patient access to healthcare. It includes tools for searching and processing National Provider Identifier (NPI) numbers based on names and analyzing demographic data associated with these NPIs. The package simplifies the handling of NPI data and the creation of informative tables for analysis and reporting. The second goal is to assist with workforce distribution research for OBGYNs.  


### PR DESCRIPTION
## Summary
- add lifecycle badges to README
- declare `split_and_save()` as stable
- declare `calculate_intersection_overlap_and_save()` as experimental

## Testing
- `testthat::test_dir('tests/testthat', reporter='summary')` *(fails: there is no package called 'testthat' / other dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_68648d75f404832caca52e231462dd79