### PR TITLE
Fix pkgdown build with .nojekyll

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -88,6 +88,9 @@ jobs:
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
+
+      - name: Disable Jekyll
+        run: touch docs/.nojekyll
       - name: Deploy to GitHub pages 🚀
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:

--- a/.github/workflows/pkgdown-deploy.yml
+++ b/.github/workflows/pkgdown-deploy.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
+
+      - name: Disable Jekyll
+        run: touch docs/.nojekyll
       - name: Deploy to GitHub Pages 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.5.0

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -59,6 +59,9 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
+      - name: Disable Jekyll
+        run: touch docs/.nojekyll
+
       - name: Deploy to GitHub Pages 🚀
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@
 R/geocode.R
 scripts/R/geocode.R
 docs
+!docs/
 inst/doc
 /Meta/
 ^\\.secrets$
 ^\\.cache$
 ^docs$
+!docs/.nojekyll


### PR DESCRIPTION
## Summary
- add .nojekyll to docs folder and allow it in `.gitignore`
- ensure pkgdown workflows create `.nojekyll` before deploying

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a26c4470832c907235a68a2bc652