### PR TITLE
Fix missing packages in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,13 +79,11 @@ Imports:
     zipcodeR
 LazyData: true
 Files: R/
-Suggests: 
+Suggests:
     knitr,
     pkgdown,
     rmarkdown,
-    stats,
-    provider,
-    genderdata
+    stats
 VignetteBuilder: knitr
 VignetteEngine: knitr::rmarkdown
 Config/pkgdown/doc_url: https://mufflyt.github.io/tyler/


### PR DESCRIPTION
## Summary
- remove provider and genderdata from the `Suggests` field of the DESCRIPTION file

## Testing
- `R -q -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a68e6d40832c9cb70482f124d484