### PR TITLE
Fix syntax error in create_isochrones_for_dataframe

### DIFF
--- a/R/create_isochrones_for_dataframe.R
+++ b/R/create_isochrones_for_dataframe.R
@@ -77,8 +77,24 @@ create_isochrones_for_dataframe <- function(input_file, breaks = c(1800, 3600, 7
   }
 
   # Save the isochrones data to an RDS file
-  readr::write_rds(isochrones, file.path(output_dir, paste0("isochrones_raw_output_from_here_api_", format(Sys.time(), "%Y-%m-%d_%H-%M-%S"), ".rds")))
+  readr::write_rds(
+    isochrones,
+    file.path(
+      output_dir,
+      paste0(
+        "isochrones_raw_output_from_here_api_",
+        format(Sys.time(), "%Y-%m-%d_%H-%M-%S"),
+        ".rds"
+      )
+    )
+  )
   beepr::beep(2)
+
+  # Collapse the list of results into a single data frame
+  isochrones <- data.table::rbindlist(isochrones_temp, fill = TRUE)
+
+  return(isochrones)
+}
 
 # Usage example:
 #isochrones_data <- create_isochrones_for_dataframe(input_file, breaks = c(1800, 3600, 7200, 10800))


### PR DESCRIPTION
## Summary
- close function body in `create_isochrones_for_dataframe`
- write output rds with formatted time and collapse list of results

## Testing
- `R -q -e 'devtools::document(); devtools::build(); devtools::check()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864aad8de1c832c8fbfe289331255ab