### PR TITLE
Remove provider from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,8 +83,7 @@ Suggests:
     knitr,
     pkgdown,
     rmarkdown,
-    stats,
-    provider
+    stats
 VignetteBuilder: knitr
 VignetteEngine: knitr::rmarkdown
 Config/pkgdown/doc_url: https://mufflyt.github.io/tyler/


### PR DESCRIPTION
## Summary
- remove the unused `provider` package from `Suggests`

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b1c4da88832cbb94a35eed707436