### PR TITLE
Fix coverage workflow and add covr

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -37,22 +37,9 @@ jobs:
           needs: coverage
 
       - name: Test coverage
-        run: |
-          cov <- covr::package_coverage(
-            quiet = FALSE,
-            clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
-          )
-          covr::to_cobertura(cov)
+        run: covr::codecov()
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
-          plugin: noop
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,6 +85,7 @@ Suggests:
     knitr,
     pkgdown,
     rmarkdown,
+    covr,
     stats
 VignetteBuilder: knitr
 VignetteEngine: knitr::rmarkdown


### PR DESCRIPTION
## Summary
- add `covr` to the package `Suggests`
- simplify coverage workflow and upload directly with `covr::codecov()`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686563f99a3c832ca6c585ca679efea9