### PR TITLE
Clarify genderdata dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ RoxygenNote: 7.3.2
 License: MIT + file LICENSE
 URL: https://github.com/mufflyt/tyler, https://mufflyt.github.io/tyler/
 BugReports: https://github.com/mufflyt/tyler/issues
+Remotes: lmullen/genderdata
 Date: 2024-06-28
 Lifecycle: experimental
 Keywords: healthcare, patient access, audit study, NPI

--- a/R/genderize_physicians.R
+++ b/R/genderize_physicians.R
@@ -4,6 +4,10 @@
 #' and joins the gender information back to the original data. It then saves the
 #' result to a new CSV file with a timestamp.
 #'
+#' This function requires the **genderdata** package, which is only available on
+#' GitHub. Install it with `remotes::install_github("lmullen/genderdata")` if
+#' you encounter an error about a missing package.
+#'
 #' @param input_csv The path to the input CSV file containing physician data.
 #' @param output_dir The directory where the output CSV file will be saved. Default is the current working directory.
 #' @return A data frame with genderized information joined to the original data.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,18 @@ NULL
 ```
 
 ### Searching for Data: `tyler::genderize_physicians`
-This is a wrapper around the `gender` package to help fill in the gender of physician names.  It requires a csv with a column called `first_name`.  A lot of gender data was found via Physician Compare in the past.  
+This is a wrapper around the `gender` package to help fill in the gender of physician names.  It requires a csv with a column called `first_name`.  A lot of gender data was found via Physician Compare in the past.
+
+`genderize_physicians()` also requires the **genderdata** package, which is only
+available on GitHub. If you encounter an error stating that `genderdata` is
+missing, install it with:
+
+```r
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes")
+}
+remotes::install_github("lmullen/genderdata")
+```
 ```r
 tyler::genderize_physicians <- function(input_csv) 
 ```

--- a/man/genderize_physicians.Rd
+++ b/man/genderize_physicians.Rd
@@ -18,6 +18,8 @@ A data frame with genderized information joined to the original data.
 This function reads a CSV file containing physician data, genderizes the first names,
 and joins the gender information back to the original data. It then saves the
 result to a new CSV file with a timestamp.
+This function requires the \code{genderdata} package. If it is not installed,
+run \code{remotes::install_github("lmullen/genderdata")}. 
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Summary
- add genderdata installation note in README and docs
- mention genderdata requirement in function documentation
- list `lmullen/genderdata` under `Remotes` in DESCRIPTION

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_686541ef0fac832c9ecdecf13ba6982c