### PR TITLE
Refresh documentation for current workflows

### DIFF
--- a/R/tyler-package.R
+++ b/R/tyler-package.R
@@ -1,4 +1,6 @@
 #' @keywords NPPES NPI healthcare internal
+#' @seealso <https://github.com/mufflyt/tyler>
+#' @seealso <https://mufflyt.github.io/tyler/>
 "_PACKAGE"
 
 ## usethis namespace: start

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![R-CMD-check](https://github.com/mufflyt/tyler/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/mufflyt/tyler/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-The goal of the 'tyler' package provides a collection of functions designed to facilitate mystery caller studies, often used in evaluating patient access to healthcare. It includes tools for searching and processing National Provider Identifier (NPI) numbers based on names and analyzing demographic data associated with these NPIs. The package simplifies the handling of NPI data and the creation of informative tables for analysis and reporting. The second goal is to assist with workforce distribution research for OBGYNs.  
+The 'tyler' package provides a collection of functions designed to facilitate mystery caller studies, often used in evaluating patient access to healthcare. It includes tools for searching and processing National Provider Identifier (NPI) numbers based on names and analyzing demographic data associated with these NPIs. The package simplifies the handling of NPI data and the creation of informative tables for analysis and reporting. The second goal is to assist with workforce distribution research for OBGYNs.  
 
 ## Installation
 
@@ -19,9 +19,11 @@ You can install the development version of tyler from [GitHub](https://github.co
 devtools::install_github("mufflyt/tyler")
 ```
 
-See the package vignette for a fuller introduction and suggestions on how to use the `tyler()` function efficiently.
+See the package vignettes for a fuller introduction. You can review them in R with:
 
-vignette(topic = "????", package = "tyler")
+```r
+browseVignettes("tyler")
+```
 
 ## Use Cases
 
@@ -35,31 +37,17 @@ The package vignettes highlight practical workflows for working with provider da
 - [Aggregating Provider Data](https://mufflyt.github.io/tyler/articles/aggregating_provider_data.html) – combine multiple data sources into a single dataset.
 
 
-### Add in hospital information data from the AHA scraper!!!!
+## Workflow overview
 
-# Workflow 👨‍🦲
-1) Gather all the physician data that is needed:
-     * Search by subspecialty taxonomy: `tyler::taxonomy` and `tyler::search_by_taxonomy` 👨‍🦲
-     * Search by physician name in `goba`: `tyler::search_and_process_npi` 👨‍🦲
-     * Merge these two physician data sources together.  See the code at: `exploratory/Workforce/subspecialists_only`  👨‍🦲
-     * Add in the physician age from healthgrades.com: ??????
-     * Get Physician Compare physician demographics: `tyler::retrieve_clinician_data`  👨‍🦲
-     * Complete the gender for all physicians: `tyler::genderize_physicians` 
-     * Check with secondary sources...
-       
-3) By state name determine the ACOG District.
-      * dplyr::left_join with `tyler::ACOG_Districts`
-5) Geocode the addresses to latitude and longitude for mapping. 👨‍🦲
-6) Get the US Census Bureau data associated with the block groups:
-   * `tyler::get_census_data` 👨‍🦲
-7) Create the isochrones based on drive times: 
-   * `tyler::create_isochrones` 👨‍🦲
-   * `tyler::create_isochrones_for_dataframe` 👨‍🦲
-   * All this is heavily borrowed from "https://github.com/khnews/2021-delta-appalachia-stroke-access"
-8) Create overlap maps of isochrones and block groups
-   * `tyler::calculate_intersection_overlap_and_save`- THIS NEEDS WORK
-   * `tyler::create_block_group_overlap_map`
-   * 
+The package functions are designed to be composed into repeatable workflows for workforce and access studies. A typical project might:
+
+1. **Assemble a physician roster.** Use `tyler::taxonomy` with `tyler::search_by_taxonomy()` to download specialty-specific NPI records and `tyler::search_and_process_npi()` to resolve NPIs for locally curated name lists. Combine the results with institutional rosters (examples live in `exploratory/Workforce/subspecialists_only`).
+2. **Enrich demographic fields.** Call `tyler::retrieve_clinician_data()` to pull CMS demographics, apply `tyler::genderize_physicians()` to infer gender (writing the result to an output directory), and cross-check values against secondary sources before finalizing the dataset.
+3. **Map providers to regions.** Join the roster to `tyler::ACOG_Districts` or other lookup tables to assign territories, and geocode any missing coordinates with `tyler::search_and_process_npi()` outputs or your preferred geocoder.
+4. **Add environmental context.** Retrieve Census indicators with `tyler::get_census_data()` and other data products (e.g., hospital directories) to support downstream analyses.
+5. **Model travel access.** Generate drive-time polygons with `tyler::create_isochrones()` or `tyler::create_isochrones_for_dataframe()`, then intersect them with census geographies using helpers such as `tyler::calculate_intersection_overlap_and_save()` and `tyler::create_block_group_overlap_map()`.
+
+Each vignette linked below walks through one part of this workflow in more detail.
 
 # Data: Workforce
 ### Data: `tyler::acgme`
@@ -214,7 +202,7 @@ if (!requireNamespace("remotes", quietly = TRUE)) {
 remotes::install_github("lmullen/genderdata")
 ```
 ```r
-tyler::genderize_physicians <- function(input_csv) 
+tyler::genderize_physicians <- function(input_csv, output_dir = getwd()) 
 ```
 
 # GET ISOCHRONES
@@ -259,7 +247,7 @@ A function that iterates the `tyler::create_isochrones` over an entire dataframe
 ```r
 isochrones_data <- tyler::create_isochrones_for_dataframe(gyn_onc, breaks = c(0, 30, 60, 120, 180))
 ```
-### `tyler::create_individual_isochrone_plots.R`
+### `tyler::create_individual_isochrone_plots`
 Function to create individual plots and shapefiles for specified drive times.  It generates individual plots for each drive time, providing a visual representation of the accessible areas on a map. The function shapefiles, which are geospatial data files used for storing geographic information, including the boundaries of the reachable areas.
 ```r
 # Usage example:

--- a/man/tyler-package.Rd
+++ b/man/tyler-package.Rd
@@ -11,7 +11,7 @@ The 'tyler' package provides a collection of functions designed to facilitate my
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://your.package.url}
+  \item \url{https://github.com/mufflyt/tyler}
   \item \url{https://mufflyt.github.io/tyler/}
 }
 

--- a/vignettes/aggregating_provider_data.Rmd
+++ b/vignettes/aggregating_provider_data.Rmd
@@ -6,7 +6,7 @@ output:
   rmarkdown::html_vignette:
     df_print: kable
 description: >
-  A skeleton vignette describing how to aggregate provider data from multiple sources.
+  Walk through a reproducible workflow for combining provider rosters with reference tables and demographic context.
 vignette: >
   %\VignetteIndexEntry{Aggregating Provider Data for Analysis}
   %\VignetteEncoding{UTF-8}
@@ -15,50 +15,137 @@ editor_options:
   chunk_output_type: console
 ---
 
-# Objectives
+# Overview
 
-- Demonstrate a workflow for combining provider datasets.
-- Show how to clean and standardize fields prior to merging.
-- Provide a starting point for further analysis.
+Mystery caller and workforce studies often start with multiple rosters that were
+assembled for different purposes. This vignette demonstrates how to tidy those
+inputs and merge them into a single analytic table that contains provider,
+regional, and demographic attributes.
 
-# Required Packages
+The example uses small, reproducible data frames so you can adapt the code to
+your environment. Replace the simulated inputs with your own CSV exports when
+you are ready to run the workflow at scale.
 
-```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
-# library(tyler)
+# Required packages
+
+```{r setup, message=FALSE}
+knitr::opts_chunk$set(collapse = TRUE)
+
+library(dplyr)
+library(readr)
+library(stringr)
+library(tidyr)
+library(tyler)
 ```
 
-# Inputs
+# 1. Start from your rosters
 
-Describe the input files such as NPI exports, Census data, and geocoded locations.
+In practice you might have one list from a specialty society and another from
+your hospital credentialing team. The code below simulates the structure of two
+CSV extracts. Replace the data frames with `readr::read_csv()` calls to use your
+real files.
 
 ```{r}
-# Example placeholder for reading data
-# npi_data <- readr::read_csv("npi.csv")
-# census_data <- readr::read_csv("census.csv")
+subspecialist_directory <- tibble::tribble(
+  ~npi,        ~first_name, ~last_name,   ~state, ~subspecialty,
+  "1194062499", "Jaclyn",    "Denetclaw", "MI",   "Obstetrics & Gynecology",
+  "1710392194", "Geeta",     "Swamy",     "NC",   "Maternal & Fetal Medicine",
+  "1922051358", "Katherine", "Boyd",      "MI",   "Female Pelvic Medicine"
+)
+
+credentialing_extract <- tibble::tribble(
+  ~npi,        ~preferred_name, ~facility,                   ~latitude, ~longitude,
+  "1194062499", "Jaclyn Denetclaw", "Spectrum Health Medical Group", 42.930,  -85.610,
+  "1750344388", "Thomas Byrne",      "Covenant Medical Center",      43.420,  -83.950,
+  "1922051358", "Katherine Boyd",    "Beaumont Hospital",            42.600,  -82.910
+)
 ```
 
-# Processing Steps
+# 2. Standardise shared fields
 
-Outline the steps needed to clean names, join datasets, and summarize counts.
+Clean simple columns before joining so that joins succeed deterministically.
+Here we harmonise the name fields and make sure the state code is uppercase.
 
 ```{r}
-# Example data manipulation steps
-# combined <- dplyr::left_join(npi_data, census_data, by = "fips")
+clean_directory <- subspecialist_directory %>%
+  mutate(
+    first_name = str_to_title(first_name),
+    last_name = str_to_title(last_name),
+    state = str_to_upper(state)
+  )
 ```
 
-# Output Examples
+# 3. Join rosters and fill gaps
 
-Show an example of the aggregated output such as counts by county.
+Use a full join on the NPI so you preserve every record. When multiple sources
+provide the same attribute, coalesce them to pick the first non-missing value.
 
 ```{r}
-# aggregated <- combined %>% dplyr::count(county)
-# aggregated
+combined_roster <- clean_directory %>%
+  full_join(credentialing_extract, by = "npi") %>%
+  mutate(
+    provider_name = coalesce(preferred_name, paste(first_name, last_name)),
+    subspecialty = coalesce(subspecialty, "Unknown"),
+    latitude = as.numeric(latitude),
+    longitude = as.numeric(longitude)
+  )
+
+combined_roster
 ```
 
-# Conclusions
+# 4. Enrich with reference data
 
-Summarize the results and next steps for analysis.
+`tyler` ships with helper tables, including `tyler::ACOG_Districts`, that you can
+use to assign geographic regions. Joining on the state abbreviation adds the
+appropriate district label.
 
-# Features and bugs
-If you have ideas for other features that would make data aggregation easier, or find a bug, the best approach is to either report it or add it!
+```{r}
+roster_with_districts <- combined_roster %>%
+  left_join(tyler::ACOG_Districts %>% select(State_Abbreviations, ACOG_District),
+            by = c(state = "State_Abbreviations"))
+
+roster_with_districts
+```
+
+# 5. Summarise for reporting
+
+Once the roster has consistent identifiers and regional tags, it becomes easy to
+produce summaries. The example below counts providers by district and
+subspecialty, then calculates the share each subspecialty represents within its
+district.
+
+```{r}
+district_summary <- roster_with_districts %>%
+  count(ACOG_District, subspecialty, name = "provider_count") %>%
+  group_by(ACOG_District) %>%
+  mutate(share = provider_count / sum(provider_count)) %>%
+  arrange(ACOG_District, desc(provider_count))
+
+district_summary
+```
+
+# 6. Save intermediate results
+
+Use `readr::write_csv()` to capture interim tables for auditing or to feed other
+systems (e.g., mapping workflows or gender inference with
+`tyler::genderize_physicians()`).
+
+```{r, eval=FALSE}
+readr::write_csv(roster_with_districts, "data/combined_roster.csv")
+readr::write_csv(district_summary, "data/district_summary.csv")
+```
+
+# Next steps
+
+From here you can:
+
+- Pass the roster to `tyler::retrieve_clinician_data()` to append CMS provider
+  demographics.
+- Validate NPIs with `tyler::validate_and_remove_invalid_npi()` before running
+  downstream analyses.
+- Create drive-time polygons using `tyler::create_isochrones_for_dataframe()` to
+  quantify geographic access.
+
+Adapt the pattern shown above to suit the specific files and lookup tables
+available in your project. Keeping joins explicit and saving intermediate outputs
+makes collaborative provider aggregation projects easier to audit and repeat.


### PR DESCRIPTION
## Summary
- revise the README to describe the current workflows, update vignette navigation guidance, and fix helper usage examples
- expand the Aggregating Provider Data vignette with a reproducible roster-merging walkthrough
- point the package manual page and roxygen metadata to the published project URLs

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68f81b9e26b0832c88b5d20abbe6a2c7