### PR TITLE
Harden census and NPI utilities with validation and tests

### DIFF
--- a/R/get_census_data.R
+++ b/R/get_census_data.R
@@ -6,9 +6,16 @@
 #' @param us_fips_list A vector of state FIPS codes which Census data is to be retrieved.
 #' @param vintage The vintage year is Census data (default is 2022).
 #'
+#' @param api_key API key string. Defaults to the `CENSUS_API_KEY` environment
+#'   variable.
+#' @param quiet Should progress messages be suppressed? Default is `FALSE`.
+#'
 #' @return A dataframe containing Census data all state block groups.
 #' @importFrom dplyr bind_rows
 #' @importFrom censusapi getCensus
+#' @importFrom purrr compact
+#' @importFrom tibble tibble
+#' @importFrom stringr str_pad
 #' @family census
 #' @export
 #' @examples
@@ -16,39 +23,72 @@
 #' us_fips_list <- c("01", "02")
 #' census_df <- get_census_data(us_fips_list)
 #' }
-get_census_data <- function(us_fips_list, vintage = 2022, api_key = Sys.getenv("CENSUS_API_KEY")) {
+get_census_data <- function(us_fips_list, vintage = 2022, api_key = Sys.getenv("CENSUS_API_KEY"), quiet = getOption("tyler.quiet", FALSE)) {
 
-  library(dplyr)
-  library(censusapi)
-  if (api_key == "") stop("Census API key required via argument or CENSUS_API_KEY env var.")
+  if (!is.atomic(us_fips_list)) {
+    stop("`us_fips_list` must be an atomic vector of state FIPS codes.")
+  }
+
+  us_fips_list <- as.character(us_fips_list)
+  if (length(us_fips_list) == 0) {
+    return(tibble::tibble())
+  }
+
+  if (anyNA(us_fips_list) || any(us_fips_list == "")) {
+    stop("`us_fips_list` contains missing or empty values.")
+  }
+
+  if (!is.numeric(vintage) || length(vintage) != 1) {
+    stop("`vintage` must be a single numeric value.")
+  }
+
+  if (!is.character(api_key) || length(api_key) != 1 || api_key == "") {
+    stop("Census API key required via argument or CENSUS_API_KEY env var.")
+  }
+
+  us_fips_list <- stringr::str_pad(us_fips_list, width = 2, pad = "0")
 
   # Initialize an empty list to store state data
-  state_data <- list()
+  state_data <- vector("list", length(us_fips_list))
+  names(state_data) <- us_fips_list
 
   # Loop over states for block group data
   for (f in us_fips_list) {
-    cat("Processing FIPS:", f, "\n")
+    if (!quiet) {
+      message("Processing FIPS: ", f)
+    }
 
-    # Define the region for the current state
-    stateget <- paste("state:", f, "&in=county:*&in=tract:*", sep="")
+    stateget <- paste0("state:", f, "&in=county:*&in=tract:*")
 
-    # Get Census data for the current state and append it to state_data list
-    state_data[[f]] <- censusapi::getCensus(
-      name = "acs/acs5",
-      vintage = vintage,
-      vars = c("NAME", paste0("B01001_0", c("01", 26, 33:49), "E")), #B01001_001E
-      region = "block group:*",
-      regionin = stateget,
-      key = api_key
+    state_data[[f]] <- tryCatch(
+      censusapi::getCensus(
+        name = "acs/acs5",
+        vintage = vintage,
+        vars = c("NAME", paste0("B01001_0", c("01", 26, 33:49), "E")),
+        region = "block group:*",
+        regionin = stateget,
+        key = api_key
+      ),
+      error = function(e) {
+        if (!quiet) {
+          message("Failed to retrieve data for FIPS ", f, ": ", conditionMessage(e))
+        }
+        NULL
+      }
     )
   }
 
-  # Bind together all state data into a single dataframe
-  acs_raw <- dplyr::bind_rows(state_data)
+  acs_raw <- dplyr::bind_rows(purrr::compact(state_data))
 
-  Sys.sleep(1)
-  beepr::beep(2)
-  return(acs_raw)
+  if (nrow(acs_raw) == 0) {
+    return(tibble::tibble())
+  }
+
+  if (requireNamespace("beepr", quietly = TRUE) && !quiet) {
+    beepr::beep(2)
+  }
+
+  acs_raw
 }
 
 # Usage example:

--- a/tests/testthat/test-get_census_data.R
+++ b/tests/testthat/test-get_census_data.R
@@ -1,100 +1,49 @@
 library(testthat)
-library(dplyr)
 library(mockery)
-library(censusapi)
 
-# Define the get_census_data function for the testing environment
-get_census_data <- function(us_fips_list, vintage = 2022) {
-  library(dplyr)
-  library(censusapi)
-
-  # Initialize an empty list to store state data
-  state_data <- list()
-
-  # Loop over states for block group data
-  for (f in us_fips_list) {
-    cat("Processing FIPS:", f, "\n")
-
-    # Define the region for the current state
-    stateget <- paste("state:", f, "&in=county:*&in=tract:*", sep = "")
-
-    # Get Census data for the current state and append it to state_data list
-    state_data[[f]] <- censusapi::getCensus(
-      name = "acs/acs5",
-      vintage = vintage,
-      vars = c("NAME", paste0("B01001_0", c("01", 26, 33:49), "E")), # B01001_001E
-      region = "block group:*",
-      regionin = stateget,
-      key = "485c6da8987af0b9829c25f899f2393b4bb1a4fb"
-    )
-  }
-
-  # Bind together all state data into a single dataframe
-  acs_raw <- dplyr::bind_rows(state_data)
-
-  Sys.sleep(1)
-  return(acs_raw)
-}
-
-# Mock function to simulate censusapi::getCensus
 mock_getCensus <- function(name, vintage, vars, region, regionin, key) {
-  cat("Mock getCensus called with:", regionin, "\n")
-  return(data.frame(
+  data.frame(
     NAME = paste("Block Group", regionin),
-    B01001_001E = sample(100:1000, 1),
-    B01001_026E = sample(100:1000, 1),
-    B01001_033E = sample(100:1000, 1),
-    B01001_034E = sample(100:1000, 1),
-    B01001_035E = sample(100:1000, 1),
-    B01001_036E = sample(100:1000, 1),
-    B01001_037E = sample(100:1000, 1),
-    B01001_038E = sample(100:1000, 1),
-    B01001_039E = sample(100:1000, 1),
-    B01001_040E = sample(100:1000, 1),
-    B01001_041E = sample(100:1000, 1),
-    B01001_042E = sample(100:1000, 1),
-    B01001_043E = sample(100:1000, 1),
-    B01001_044E = sample(100:1000, 1),
-    B01001_045E = sample(100:1000, 1),
-    B01001_046E = sample(100:1000, 1),
-    B01001_047E = sample(100:1000, 1),
-    B01001_048E = sample(100:1000, 1),
-    B01001_049E = sample(100:1000, 1)
-  ))
+    B01001_001E = 1,
+    B01001_026E = 2
+  )
 }
 
-# Test cases
 test_that("Retrieves Census data for valid FIPS codes", {
-  cat("Running test: Retrieves Census data for valid FIPS codes\n")
-  valid_fips <- c("01", "02")
-
-  # Stub the getCensus function
+  old <- options(tyler.quiet = TRUE)
+  on.exit(options(old), add = TRUE)
   stub(get_census_data, 'censusapi::getCensus', mock_getCensus)
-
-  result <- get_census_data(valid_fips)
-
-  expect_true(nrow(result) > 0)
-  expect_true("NAME" %in% colnames(result))
-  expect_true("B01001_001E" %in% colnames(result))
+  result <- get_census_data(c("1", "02"), vintage = 2022, api_key = "key", quiet = TRUE)
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 2)
 })
 
-test_that("Handles empty FIPS list gracefully", {
-  cat("Running test: Handles empty FIPS list gracefully\n")
-  empty_fips <- c()
-
-  result <- get_census_data(empty_fips)
-
+test_that("Empty FIPS list returns empty tibble", {
+  result <- get_census_data(character(0), api_key = "key", quiet = TRUE)
+  expect_s3_class(result, "tbl_df")
   expect_equal(nrow(result), 0)
 })
 
-test_that("Handles invalid FIPS codes gracefully", {
-  cat("Running test: Handles invalid FIPS codes gracefully\n")
-  invalid_fips <- c("ZZ", "XX")
+test_that("Non atomic input triggers error", {
+  expect_error(get_census_data(list("01"), api_key = "key"), "atomic vector")
+})
 
-  # Stub the getCensus function to return NULL for invalid FIPS
-  stub(get_census_data, 'censusapi::getCensus', function(...) NULL)
+test_that("Missing FIPS values trigger error", {
+  expect_error(get_census_data(c("01", NA), api_key = "key"), "missing or empty")
+})
 
-  result <- get_census_data(invalid_fips)
+test_that("Invalid vintage triggers error", {
+  expect_error(get_census_data("01", vintage = c(2020, 2021), api_key = "key"), "single numeric")
+})
 
+test_that("Missing API key triggers error", {
+  expect_error(get_census_data("01", api_key = ""), "Census API key required")
+})
+
+test_that("Handles API failures gracefully", {
+  old <- options(tyler.quiet = TRUE)
+  on.exit(options(old), add = TRUE)
+  stub(get_census_data, 'censusapi::getCensus', function(...) stop("boom"))
+  result <- get_census_data("01", api_key = "key", quiet = TRUE)
   expect_equal(nrow(result), 0)
 })


### PR DESCRIPTION
## Summary
- harden `get_census_data()` with strict input validation, optional quiet mode, and resilient API handling
- strengthen `search_and_process_npi()` by validating arguments, controlling side effects, and filtering credentials safely
- add twelve edge-case focused unit tests covering both utilities, including failure modes and directory handling

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat', reporter = 'summary')"` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f81c09f188832c97fb479f4e300848