### PR TITLE
Refactor Phase 2 exports to avoid setwd

### DIFF
--- a/R/clean_phase_2_results.R
+++ b/R/clean_phase_2_results.R
@@ -71,6 +71,8 @@ rename_columns_by_substring <- function(data, target_strings, new_names) {
 #' @param data_or_path Path to the data file or a data frame.
 #' @param required_strings Vector of substrings for which to search in column names.
 #' @param standard_names Vector of new names to apply to the matched columns.
+#' @param output_directory Directory where the cleaned CSV should be written.
+#'   Defaults to the project root resolved via [here::here()].
 #' @return A data frame with processed data.
 #' @export
 #' @importFrom readr read_csv write_csv
@@ -92,7 +94,12 @@ rename_columns_by_substring <- function(data, target_strings, new_names) {
 #' standard_names <- c("doctor_info", "patient_contact_info")
 #' cleaned_df <- clean_phase_2_data(df, required_strings, standard_names)
 #' print(cleaned_df)
-clean_phase_2_data <- function(data_or_path, required_strings, standard_names) {
+clean_phase_2_data <- function(
+  data_or_path,
+  required_strings,
+  standard_names,
+  output_directory = here::here()
+) {
   # Data loading and initial checks
   if (is.character(data_or_path)) {
     if (!file.exists(data_or_path)) {
@@ -118,8 +125,12 @@ clean_phase_2_data <- function(data_or_path, required_strings, standard_names) {
   message("Proceeding with additional data processing steps...")
 
   # Saving the cleaned data
+  if (!dir.exists(output_directory)) {
+    dir.create(output_directory, recursive = TRUE, showWarnings = FALSE)
+  }
+
   current_datetime <- format(Sys.time(), "%Y-%m-%d_%H-%M-%S")
-  output_file_path <- paste0("cleaned_phase_2_data_", current_datetime, ".csv")
+  output_file_path <- file.path(output_directory, paste0("cleaned_phase_2_data_", current_datetime, ".csv"))
   readr::write_csv(data, output_file_path)
   message("Cleaned data successfully saved to: ", output_file_path)
 

--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -19,6 +19,8 @@
 #'   complete and per-caller workbooks.
 #' @param phase2_data Data frame or file path consumed by
 #'   [clean_phase_2_data()].
+#' @param phase2_output_directory Directory where Phase 2 exports should be
+#'   written. Defaults to `output_directory`.
 #' @param quality_check_path File path where [save_quality_check_table()] should
 #'   write the quality check CSV.
 #' @param phase1_output_directory Directory where [clean_phase_1_results()]
@@ -54,6 +56,7 @@ run_mystery_caller_workflow <- function(
   lab_assistant_names,
   output_directory,
   phase2_data,
+  phase2_output_directory = output_directory,
   quality_check_path,
   phase1_output_directory = output_directory,
   split_insurance_order = c("Medicaid", "Blue Cross/Blue Shield"),
@@ -182,7 +185,8 @@ run_mystery_caller_workflow <- function(
   cleaned_phase2 <- clean_phase_2_data(
     data_or_path = phase2_data,
     required_strings = phase2_required_strings,
-    standard_names = phase2_standard_names
+    standard_names = phase2_standard_names,
+    output_directory = phase2_output_directory
   )
 
   coverage_summary <- NULL

--- a/tests/testthat/test-arsenal_tables_write2word.R
+++ b/tests/testthat/test-arsenal_tables_write2word.R
@@ -2,25 +2,6 @@ library(testthat)
 testthat::skip_if_not_installed("arsenal")
 library(arsenal)
 
-# Setup and cleanup functions to manage the test environment
-setup <- function() {
-  test_dir <- tempdir()  # Creates a unique temporary directory for testing
-  tables_dir <- file.path(test_dir, "tables")
-  if (!dir.exists(tables_dir)) {
-    dir.create(tables_dir, recursive = TRUE)  # Ensures the 'tables' directory exists
-  }
-  on.exit({
-    setwd(old_dir)  # Restores the original working directory when the test ends
-    unlink(tables_dir, recursive = TRUE)  # Removes the 'tables' directory
-  }, add = TRUE)
-  old_dir <- setwd(test_dir)  # Changes the working directory to the test directory
-  list(test_dir = test_dir, tables_dir = tables_dir)
-}
-
-cleanup <- function(path) {
-  unlink(path, recursive = TRUE)  # Deletes the directory created during setup
-}
-
 # Define the test cases
 test_that("errors are thrown for invalid inputs", {
   expect_error(arsenal_tables_write2word(123, "filename"), "Error: 'object' must be a data frame object.")

--- a/tests/testthat/test-run_mystery_caller_workflow.R
+++ b/tests/testthat/test-run_mystery_caller_workflow.R
@@ -17,12 +17,7 @@ skip_if_not_installed("fs")
 test_that("run_mystery_caller_workflow orchestrates pipeline without mocks", {
   work_dir <- tempfile("tyler-e2e-")
   dir.create(work_dir, recursive = TRUE, showWarnings = FALSE)
-  old_wd <- getwd()
-  on.exit({
-    setwd(old_wd)
-    unlink(work_dir, recursive = TRUE)
-  }, add = TRUE)
-  setwd(work_dir)
+  on.exit(unlink(work_dir, recursive = TRUE), add = TRUE)
 
   phase1_out <- file.path(work_dir, "phase1")
   splits_dir <- file.path(work_dir, "splits")
@@ -63,6 +58,7 @@ test_that("run_mystery_caller_workflow orchestrates pipeline without mocks", {
     phase2_data = phase2_data,
     quality_check_path = qc_path,
     phase1_output_directory = phase1_out,
+    phase2_output_directory = work_dir,
     all_states = c("Colorado", "Wyoming")
   )
 


### PR DESCRIPTION
## Summary
- allow `clean_phase_2_data()` to write outputs to a caller-supplied directory resolved with `here::here()`
- add a matching `phase2_output_directory` option to `run_mystery_caller_workflow()`
- update integration and regression tests to avoid `setwd()` usage

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: `Rscript` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fab38158b4832cba04e0a99befd855