### PR TITLE
Fix case-insensitive exact-match renaming in Phase 2 column cleaner

### DIFF
--- a/R/clean_phase_2_results.R
+++ b/R/clean_phase_2_results.R
@@ -64,7 +64,7 @@ rename_columns_by_substring <- function(data, target_strings, new_names) {
         ))
       }
       # Rename the matching column
-      names(data)[names(data) == matched_cols[1]] <- new_names[i]
+      names(data)[which(matches)[1]] <- new_names[i]
       rename_index <- rename_index + 1L
       rename_log[[rename_index]] <- data.frame(
         pattern = target_strings[i],
@@ -78,7 +78,7 @@ rename_columns_by_substring <- function(data, target_strings, new_names) {
         new_names[i]
       ))
     } else {
-      warning(sprintf("No columns contained '%s'; nothing was renamed for this pattern.", target_strings[i]))
+      warning(sprintf("No columns exactly matched '%s'; nothing was renamed for this pattern.", target_strings[i]))
     }
     message("")  # Adding a blank line for better separation
   }

--- a/tests/testthat/test-clean_phase_2_results-regression.R
+++ b/tests/testthat/test-clean_phase_2_results-regression.R
@@ -1,0 +1,17 @@
+library(testthat)
+
+test_that("rename_columns_by_substring renames case-insensitive exact matches", {
+  raw <- data.frame(
+    PhysicianInformation = c("Jane"),
+    stringsAsFactors = FALSE
+  )
+
+  renamed <- rename_columns_by_substring(
+    raw,
+    target_strings = "physicianinformation",
+    new_names = "physician_info"
+  )
+
+  expect_true("physician_info" %in% names(renamed))
+  expect_false("PhysicianInformation" %in% names(renamed))
+})


### PR DESCRIPTION
### Motivation
- `clean_phase_2_data()` standardizes incoming Phase 2 exports and relies on `rename_columns_by_substring()` to map column names to canonical names, but mixed-case source columns could be missed due to inconsistent rename logic. 
- The change ensures case-insensitive exact-match detection and the actual rename operation are consistent so downstream standardization is reliable.

### Description
- Use the matched index when renaming so the actual replacement follows the case-insensitive exact-match test (`names(data)[which(matches)[1]] <- new_names[i]`).
- Update the warning text to correctly state that no columns "exactly matched" the pattern instead of implying substring behavior.
- Add a regression test `tests/testthat/test-clean_phase_2_results-regression.R` that verifies case-insensitive exact-match renaming works for mixed-case source columns.

### Testing
- Attempted to run R tests via `R -q -e 'testthat::test_file(...)'` but the environment lacks `R`, resulting in failure: `/bin/bash: R: command not found` so no R tests were executed.
- Added the regression test file `tests/testthat/test-clean_phase_2_results-regression.R` (created for automated test suites; not executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f2111dfc832c950a9a9dbbc3d2d6)