### PR TITLE
Disable automatic GitHub Actions workflow triggers

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  workflow_dispatch:
 
 name: R-CMD-check
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,13 +1,10 @@
 # Build and deploy pkgdown site to GitHub Pages
 # Temporary: runs on push to bypass R-CMD-check dependency
 # Based on: https://github.com/r-lib/actions/tree/v2/examples
+on:
+  workflow_dispatch:
 
 name: pkgdown
-
-on:
-  push:
-    branches: [main, master]
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,8 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 name: Commands
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,11 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  # Temporarily disabled to fix pkgdown deployment
-  # push:
-  #   branches: [main, master]
-  # pull_request:
-  #   branches: [main, master]
   workflow_dispatch:
 
 name: test-coverage


### PR DESCRIPTION
### Motivation
- Prevent CI and automation runs from triggering on push, pull request, and issue comments while retaining the ability to run workflows manually. 
- Reduce noisy/automatic runs during development and repo maintenance by switching workflows to manual triggers only.

### Description
- Replaced automatic triggers with `workflow_dispatch` in the active workflows at `.github/workflows/R-CMD-check.yaml`, `.github/workflows/test-coverage.yaml`, `.github/workflows/pr-commands.yaml`, and `.github/workflows/pkgdown.yaml` so they only run manually. 
- Removed duplicate/secondary `on:` blocks in `pkgdown.yaml` to ensure a single manual trigger configuration. 
- Changes are limited to CI workflow trigger configuration and do not modify job steps or permissions.

### Testing
- Executed the update script that modified the workflow headers (`python - <<'PY' ...`) and the script completed successfully. 
- Inspected workflow headers with `sed -n '1,120p'` and `nl -ba` to confirm each file now contains `on: workflow_dispatch` and these checks succeeded. 
- Listed and previewed workflows with `for f in .github/workflows/*.yaml; do echo ...; sed -n '1,30p' $f; done` to validate the visible changes and this check succeeded. 
- Generated a PR description via `make_pr` to summarize the change and that operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa75cd3534832cb8db0f4ff47d9a33)