### PR TITLE
Handle missing lwgeom::st_orient in intersection workflow

### DIFF
--- a/R/calculate_intersection_overlap_and_save.R
+++ b/R/calculate_intersection_overlap_and_save.R
@@ -22,7 +22,6 @@
 #' calculate_intersection_overlap_and_save(block_groups, isochrones_joined, 30L, "data/shp/")
 #'
 #' @importFrom sf st_intersection st_write st_area st_transform st_make_valid st_is_valid st_union st_sf
-#' @importFrom lwgeom st_orient
 #' @importFrom dplyr mutate select left_join coalesce
 #' @importFrom rlang .data
 #' @importFrom stats quantile na.omit
@@ -35,6 +34,19 @@ calculate_intersection_overlap_and_save <- function(block_groups,
                                                     output_dir,
                                                     crosswalk = NULL,
                                                     notify = TRUE) {
+  orient_geometries <- function(x) {
+    if (!requireNamespace("lwgeom", quietly = TRUE)) {
+      return(x)
+    }
+
+    orient_fn <- get0("st_orient", envir = asNamespace("lwgeom"), mode = "function")
+    if (is.null(orient_fn)) {
+      return(x)
+    }
+
+    orient_fn(x)
+  }
+
   # Parameter validation
   if (!inherits(block_groups, "sf")) {
     stop("Error: 'block_groups' must be an sf object.")
@@ -67,8 +79,8 @@ calculate_intersection_overlap_and_save <- function(block_groups,
   block_groups <- validated$block_groups
   isochrones_joined <- validated$isochrones_joined
 
-  block_groups <- lwgeom::st_orient(block_groups)
-  isochrones_joined <- lwgeom::st_orient(isochrones_joined)
+  block_groups <- orient_geometries(block_groups)
+  isochrones_joined <- orient_geometries(isochrones_joined)
 
   # Year alignment enforcement
   if (!"data_year" %in% names(isochrones_joined)) {
@@ -136,8 +148,8 @@ calculate_intersection_overlap_and_save <- function(block_groups,
     block_groups <- validated_crosswalk$block_groups
     isochrones_joined <- validated_crosswalk$isochrones_joined
 
-    block_groups <- lwgeom::st_orient(block_groups)
-    isochrones_joined <- lwgeom::st_orient(isochrones_joined)
+    block_groups <- orient_geometries(block_groups)
+    isochrones_joined <- orient_geometries(isochrones_joined)
 
     acs_years <- stats::na.omit(unique(block_groups$vintage))
     if (length(acs_years) != 1L || !identical(acs_years[[1]], provider_year)) {
@@ -181,7 +193,7 @@ calculate_intersection_overlap_and_save <- function(block_groups,
     geometry = isochrones_filtered,
     crs = sf::st_crs(isochrones_joined)
   )
-  isochrones_filtered <- lwgeom::st_orient(isochrones_filtered)
+  isochrones_filtered <- orient_geometries(isochrones_filtered)
 
   # Project to an equal-area CRS for area calculations
   block_groups_proj <- sf::st_transform(block_groups, area_crs)

--- a/R/calculate_intersection_overlap_and_save.R
+++ b/R/calculate_intersection_overlap_and_save.R
@@ -244,7 +244,7 @@ calculate_intersection_overlap_and_save <- function(block_groups,
   # Calculate area in all block groups (projected CRS)
   block_groups_proj <- block_groups_proj %>%
     dplyr::mutate(
-      bg_area = as.numeric(sf::st_area(block_groups_proj)),
+      bg_area = as.numeric(sf::st_area(.)),
       area_method = dplyr::coalesce(rlang::.data$area_method, "projected:EPSG:5070")
     )
 


### PR DESCRIPTION
### Motivation
- `calculate_intersection_overlap_and_save()` previously called `lwgeom::st_orient()` directly which can fail in environments where `st_orient` is not exported from `lwgeom`, causing intersection workflows to hard-fail.
- The change aims to preserve geometry-orientation behavior when available while degrading gracefully when `lwgeom::st_orient` is not present.

### Description
- Added a local helper `orient_geometries()` inside `calculate_intersection_overlap_and_save()` that checks for `lwgeom` and resolves `st_orient` from the package namespace before calling it, and returns its input unchanged when the function is unavailable.
- Replaced all direct `lwgeom::st_orient(...)` call sites in `calculate_intersection_overlap_and_save()` with `orient_geometries(...)` to avoid hard failures.
- Removed the roxygen `@importFrom lwgeom st_orient` directive to avoid documenting an import of a symbol that may not be exported in all installations.

### Testing
- Performed a static review and diff inspection of `R/calculate_intersection_overlap_and_save.R` to confirm all orientations were replaced and the helper was added successfully.
- Attempted to run package tests via `R -q -e "devtools::test(filter='bug-fixes')"`, but the execution environment lacks R (`/bin/bash: R: command not found`), so automated tests could not be executed here.
- No runtime regressions observed in the edited file from static checks; recommend running the package test suite in an R-enabled environment to validate runtime behavior and CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7bed5450832ca257bee8e68c533c)