### PR TITLE
Phone formatting: treat unsupported lengths as NA and add regression test

### DIFF
--- a/R/clean_phase_1_results.R
+++ b/R/clean_phase_1_results.R
@@ -451,12 +451,12 @@ format_phone_number <- function(phone_values) {
     } else if (nchar(clean) == 0) {
       ""
     } else {
-      # Bug #5 fix: Warn about invalid phone number lengths instead of silently returning malformed numbers
+      # Treat unsupported lengths as invalid and return missing value.
       warning(sprintf(
-        "Phone number has invalid length (%d digits): '%s'. Expected 7 or 10 digits. Returning as-is.",
+        "Phone number has invalid length (%d digits): '%s'. Expected 7 or 10 digits; returning NA.",
         nchar(clean), d
       ), call. = FALSE)
-      clean
+      NA_character_
     }
   }, character(1))
 

--- a/tests/testthat/test-bug-fixes.R
+++ b/tests/testthat/test-bug-fixes.R
@@ -68,6 +68,25 @@ test_that("Bug #5: Phone formatting handles edge cases", {
   })
 })
 
+
+
+test_that("Bug #5: invalid phone lengths are converted to NA in phase 1 cleaning", {
+  df <- data.frame(
+    names = c("John Doe", "Jane Doe"),
+    practice_name = c("Univ Hospital", "Private Clinic"),
+    phone_number = c("12345", "3035550100"),
+    state_name = c("CO", "CO"),
+    npi = c("1234567893", "1234567893"),
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    cleaned <- clean_phase_1_results(df, duplicate_rows = FALSE, verbose = FALSE),
+    "invalid length"
+  )
+  expect_true(is.na(cleaned$phone_number[cleaned$names == "John Doe"]))
+  expect_equal(cleaned$phone_number[cleaned$names == "Jane Doe"], "(303) 555-0100")
+})
 # ==============================================================================
 # Bug #8: Substring Column Matching
 # ==============================================================================


### PR DESCRIPTION
### Motivation
- Prevent malformed phone-digit strings from silently propagating into outputs (e.g., REDCap exports) by making invalid phone lengths explicit and easier to catch in downstream QC.

### Description
- Update `format_phone_number()` in `R/clean_phase_1_results.R` to emit a warning and return `NA_character_` for unsupported digit lengths instead of returning the raw cleaned digits. 
- Add a regression test to `tests/testthat/test-bug-fixes.R` that exercises `clean_phase_1_results()` with an invalid-length phone and a valid phone, asserting the invalid value becomes `NA` while the valid value is correctly formatted.

### Testing
- Added an automated test case in `tests/testthat/test-bug-fixes.R` that verifies the new behavior for invalid and valid phone inputs. 
- Attempted to run the test via `Rscript -e "testthat::test_file('tests/testthat/test-bug-fixes.R')"` in the CI-like environment, but the run could not be executed because `Rscript` is not installed here (no test execution results available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7bf8f8c4832cafe40a4c74e56bbf)