### PR TITLE
Normalize join key and fix join mismatches in genderize_physicians

### DIFF
--- a/R/genderize_physicians.R
+++ b/R/genderize_physicians.R
@@ -48,22 +48,28 @@ genderize_physicians <- function(input_csv, output_dir = NULL, output_format = c
   gender_Physicians <- gender_Physicians %>%
     dplyr::mutate(first_name = trimws(first_name))
 
+  join_key <- tolower(gender_Physicians$first_name)
+
   # Get first names
   first_names <- gender_Physicians$first_name
 
   resolved_genders <- genderize_fetch(first_names)
 
   x <- resolved_genders %>%
-    dplyr::distinct(first_name, .keep_all = TRUE)
+    dplyr::mutate(first_name = trimws(first_name), join_first_name = tolower(first_name)) %>%
+    dplyr::distinct(join_first_name, .keep_all = TRUE) %>%
+    dplyr::select(-dplyr::any_of(c("first_name")))
 
   # Bug #1 fix: Drop overlapping columns before join to prevent .x/.y suffixes
   # genderize_fetch() returns: first_name, gender, probability, count
   # We want the fresh API data, not any pre-existing columns with these names
   gender_Physicians_clean <- gender_Physicians %>%
-    dplyr::select(-dplyr::any_of(c("gender", "probability", "count")))
+    dplyr::select(-dplyr::any_of(c("gender", "probability", "count"))) %>%
+    dplyr::mutate(join_first_name = join_key)
 
   # Rejoin with the original database
-  y <- dplyr::left_join(gender_Physicians_clean, x, by = "first_name")
+  y <- dplyr::left_join(gender_Physicians_clean, x, by = "join_first_name") %>%
+    dplyr::select(-dplyr::any_of(c("join_first_name")))
 
   # Check for missing genders in the joined dataset
   missing_genders_joined <- sum(is.na(y$gender))


### PR DESCRIPTION
### Motivation
- Joining gender predictions back to the input roster was brittle because differences in casing/whitespace between source `first_name` values and API results caused false-miss joins and NA genders. 
- Overlapping columns (e.g., `gender`, `probability`) on both sides of the join produced `.x/.y` suffixes and an unclear output schema.

### Description
- Normalize `first_name` by trimming and lowercasing and create a dedicated `join_first_name` key on both the roster and prediction tables in `R/genderize_physicians.R` before performing the join. 
- Remove the original `first_name` from the RHS prediction frame and drop the temporary `join_first_name` column after the join so the output schema remains clean. 
- Keep the prior safeguard that drops any pre-existing `gender`, `probability`, and `count` columns from the input roster so the fresh API values are used.

### Testing
- Attempted to run `Rscript -e "testthat::test_file('tests/testthat/test-handoff-contracts.R')"` but it failed because `Rscript` is not available in the environment (`/bin/bash: Rscript: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7c111648832c98b68b773ca4b913)