### PR TITLE
Make CSV writes atomic and serialize log file appends to avoid races

### DIFF
--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -46,7 +46,22 @@ tyler_read_table <- function(path, format = NULL, ...) {
 tyler_write_table <- function(data, path, format = NULL, append = FALSE, col_names = TRUE, ...) {
   fmt <- tyler_normalize_file_format(format, path = path)
   if (identical(fmt, "csv")) {
-    readr::write_csv(data, path, append = append, col_names = col_names, ...)
+    # Atomic write for non-append mode to reduce race-condition risk when
+    # multiple processes target the same path.
+    if (!append) {
+      tmp <- tempfile(
+        pattern = paste0(basename(path), "_"),
+        tmpdir = dirname(path),
+        fileext = ".tmp"
+      )
+      readr::write_csv(data, tmp, append = FALSE, col_names = col_names, ...)
+      if (!file.rename(tmp, path)) {
+        unlink(tmp, force = TRUE)
+        stop("Failed to atomically replace file: ", path, call. = FALSE)
+      }
+    } else {
+      readr::write_csv(data, path, append = TRUE, col_names = col_names, ...)
+    }
   } else {
     tyler_require_arrow()
     if (inherits(data, "grouped_df")) {

--- a/R/utils-logging.R
+++ b/R/utils-logging.R
@@ -400,6 +400,17 @@ tyler_log_to_file <- function(msg) {
   if (!is.null(.tyler_workflow$log_file)) {
     # Remove ANSI codes and special characters for file logging
     clean_msg <- gsub("\u2713|\u2717|\u26A0|\u2139|\u25B6|\u25B8|\u21BB|\u1F4BE", "", msg)
+    lock_path <- paste0(.tyler_workflow$log_file, ".lock")
+    lock_acquired <- FALSE
+    for (i in seq_len(100)) {
+      lock_acquired <- dir.create(lock_path, showWarnings = FALSE)
+      if (lock_acquired) break
+      Sys.sleep(0.01)
+    }
+    if (!lock_acquired) {
+      stop("Unable to acquire log file lock: ", .tyler_workflow$log_file, call. = FALSE)
+    }
+    on.exit(unlink(lock_path, recursive = TRUE, force = TRUE), add = TRUE)
     write(clean_msg, file = .tyler_workflow$log_file, append = TRUE)
   }
   invisible(NULL)

--- a/tests/testthat/test-utils-io-gold-standard.R
+++ b/tests/testthat/test-utils-io-gold-standard.R
@@ -113,6 +113,19 @@ test_that("tyler_write_table - returns the path invisibly", {
   expect_equal(result, tmp)
 })
 
+test_that("tyler_write_table - non-append writes replace atomically", {
+  tmp <- tempfile(fileext = ".csv")
+  on.exit(unlink(tmp))
+
+  tyler_write_table(data.frame(x = 1:3), tmp, format = "csv")
+  tyler_write_table(data.frame(x = 4:6), tmp, format = "csv")
+  df2 <- tyler_read_table(tmp, format = "csv")
+
+  expect_equal(df2$x, 4:6)
+  tmp_sidecars <- list.files(dirname(tmp), pattern = "\\.tmp$", full.names = TRUE)
+  expect_equal(length(tmp_sidecars), 0L)
+})
+
 test_that("tyler_read_table - infers CSV format from file extension", {
   df <- data.frame(a = 1:3)
   tmp <- tempfile(fileext = ".csv")


### PR DESCRIPTION
### Motivation
- Reduce race conditions and partial-write corruption when multiple processes or rapid repeated calls write the same CSV path or the same log file.
- Logging and IO were observed as high-risk areas for concurrent access in the weakest-links analysis and concurrent-access tests.
- Preserve existing append semantics while providing safer default behavior for overwrite operations.

### Description
- `R/utils-io.R`: `tyler_write_table()` now performs atomic replace for non-append CSV writes by writing to a temporary file in the destination directory and renaming it into place, while preserving `append = TRUE` behaviour for append writes.
- `R/utils-logging.R`: `tyler_log_to_file()` now uses a lightweight lock-directory strategy (create a `.lock` dir with retries and `on.exit()` cleanup) to serialize file appends and avoid interleaved/corrupted log writes from concurrent processes.
- `tests/testthat/test-utils-io-gold-standard.R`: added a regression test verifying that repeated non-append CSV writes replace content atomically and do not leave `.tmp` sidecar files behind.

### Testing
- Added a unit regression test `tests/testthat/test-utils-io-gold-standard.R` for atomic overwrite behavior (not executed in-container as automation step below failed to run tests).
- Attempted to run the new test with `Rscript -e "testthat::test_file('tests/testthat/test-utils-io-gold-standard.R')"`, but the execution environment lacked `Rscript` so tests could not be executed here.
- Verified changes were committed and included the new test and code updates (`R/utils-io.R`, `R/utils-logging.R`, `tests/testthat/test-utils-io-gold-standard.R`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7c3d5194832ca0b60a4b508df4ed)