### PR TITLE
Add checkmate-based validation to overlap functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Maintainer: Tyler Muffly <tyler.muffly@dhha.org>
 Depends:
     R (>= 3.5.0)
 Imports:
+    checkmate,
     RColorBrewer,
     arsenal,
     broom,

--- a/R/calculate_intersection_overlap_and_save.R
+++ b/R/calculate_intersection_overlap_and_save.R
@@ -23,6 +23,7 @@
 #'
 #' @importFrom sf st_intersection st_write st_area st_transform st_make_valid st_is_valid st_union st_sf
 #' @importFrom dplyr mutate select left_join coalesce
+#' @importFrom checkmate assert_class assert_number assert_string assert_function
 #' @importFrom rlang .data
 #' @importFrom stats quantile na.omit
 #'
@@ -48,23 +49,21 @@ calculate_intersection_overlap_and_save <- function(block_groups,
   }
 
   # Parameter validation
-  if (!inherits(block_groups, "sf")) {
-    stop("Error: 'block_groups' must be an sf object.")
-  }
-  if (!inherits(isochrones_joined, "sf")) {
-    stop("Error: 'isochrones_joined' must be an sf object.")
-  }
-  if (!is.numeric(drive_time_minutes) || length(drive_time_minutes) != 1L || drive_time_minutes < 0) {
-    stop(
-      sprintf(
-        "`drive_time_minutes` must be a single non-negative numeric value; received: %s",
-        paste(drive_time_minutes, collapse = ", ")
-      ),
-      call. = FALSE
-    )
-  }
-  if (!is.character(output_dir) || length(output_dir) != 1L || !nzchar(output_dir)) {
-    stop("`output_dir` must be a single, non-empty character path.", call. = FALSE)
+  checkmate::assert_class(block_groups, "sf", .var.name = "block_groups")
+  checkmate::assert_class(isochrones_joined, "sf", .var.name = "isochrones_joined")
+  checkmate::assert_number(
+    drive_time_minutes,
+    lower = 0,
+    finite = TRUE,
+    .var.name = "drive_time_minutes"
+  )
+  checkmate::assert_string(
+    output_dir,
+    min.chars = 1,
+    .var.name = "output_dir"
+  )
+  if (!is.null(crosswalk)) {
+    checkmate::assert_function(crosswalk, .var.name = "crosswalk")
   }
 
   validated <- validate_sf_inputs(

--- a/R/map_create_block_group_overlap.R
+++ b/R/map_create_block_group_overlap.R
@@ -19,6 +19,7 @@
 #' }
 #'
 #' @importFrom dplyr arrange mutate
+#' @importFrom checkmate assert_class assert_string
 #' @importFrom htmlwidgets saveWidget
 #' @importFrom sf st_make_valid st_transform st_is_valid st_union st_sf
 #' @importFrom lwgeom st_orient
@@ -31,12 +32,9 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
   if (!requireNamespace("leaflet", quietly = TRUE)) {
     stop("Package 'leaflet' is required for map_create_block_group_overlap(). Install with: install.packages('leaflet')", call. = FALSE)
   }
-  if (!inherits(bg_data, "sf")) {
-    stop("`bg_data` must be an sf object with polygon geometries.")
-  }
-  if (!inherits(isochrones_data, "sf")) {
-    stop("`isochrones_data` must be an sf object with polygon geometries.")
-  }
+  checkmate::assert_class(bg_data, "sf", .var.name = "bg_data")
+  checkmate::assert_class(isochrones_data, "sf", .var.name = "isochrones_data")
+  checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
 
   validated <- validate_sf_inputs(
     bg_data = bg_data,

--- a/tests/testthat/test-overlap-checkmate-validations.R
+++ b/tests/testthat/test-overlap-checkmate-validations.R
@@ -1,0 +1,28 @@
+library(sf)
+
+make_square_sf <- function(...) {
+  square <- sf::st_polygon(list(rbind(c(0, 0), c(1, 0), c(1, 1), c(0, 1), c(0, 0))))
+  sf::st_sf(..., geometry = sf::st_sfc(square, crs = 4326))
+}
+
+test_that("calculate_intersection_overlap_and_save checkmate validations trigger", {
+  bg <- make_square_sf(GEOID = "000000000000", vintage = 2020)
+  iso <- make_square_sf(drive_time = 30, data_year = 2020)
+
+  expect_error(calculate_intersection_overlap_and_save(NULL, iso, 30, tempdir(), notify = FALSE), "block_groups")
+  expect_error(calculate_intersection_overlap_and_save(bg, NULL, 30, tempdir(), notify = FALSE), "isochrones_joined")
+  expect_error(calculate_intersection_overlap_and_save(bg, iso, -1, tempdir(), notify = FALSE), "drive_time_minutes")
+  expect_error(calculate_intersection_overlap_and_save(bg, iso, 30, "", notify = FALSE), "output_dir")
+  expect_error(calculate_intersection_overlap_and_save(bg, iso, 30, tempdir(), notify = "no"), "notify")
+})
+
+test_that("map_create_block_group_overlap checkmate validations trigger", {
+  bg <- make_square_sf(GEOID = "000000000000", NAMELSAD = "BG", overlap = 0.5, vintage = 2020)
+  iso <- make_square_sf(drive_time = 30)
+
+  expect_error(map_create_block_group_overlap(NULL, iso, tempdir()), "bg_data")
+  expect_error(map_create_block_group_overlap(bg, NULL, tempdir()), "isochrones_data")
+  expect_error(map_create_block_group_overlap(bg, iso, ""), "output_dir")
+  expect_error(map_create_block_group_overlap(bg |> dplyr::mutate(overlap = 1.5), iso, tempdir()), "bg_data\\$overlap")
+  expect_error(map_create_block_group_overlap(bg, iso |> dplyr::mutate(drive_time = "thirty"), tempdir()), "drive_time")
+})


### PR DESCRIPTION
### Motivation
- Replace ad-hoc, repetitive argument checks in overlap-related functions with concise, consistent assertions to improve error messages and maintenance.

### Description
- Add `checkmate` to `Imports` in `DESCRIPTION` so assertion helpers are available during package use.
- Add `@importFrom checkmate` roxygen tags and replace manual checks in `calculate_intersection_overlap_and_save()` with `checkmate::assert_class`, `checkmate::assert_number`, `checkmate::assert_string`, and `checkmate::assert_function` for the `crosswalk` parameter.
- Replace manual checks in `map_create_block_group_overlap()` with `checkmate::assert_class` and `checkmate::assert_string` and keep existing `validate_sf_inputs()` calls for downstream validation.

### Testing
- Attempted a lightweight parse-based check with `Rscript -e "parse(file='R/calculate_intersection_overlap_and_save.R'); parse(file='R/map_create_block_group_overlap.R'); cat('parse ok\n')"`, which failed because `Rscript` is not available in this environment.
- No additional automated R CMD check or unit tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa85392878832ca8f49f6f30de21b6)