### PR TITLE
Add checkmate validation to geocode_unique_addresses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     RColorBrewer,
     arsenal,
     broom,
+    checkmate,
     data.table,
     dplyr,
     emmeans,

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -41,8 +41,17 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
                                      quiet = getOption("tyler.quiet", FALSE),
                                      tracker = NULL,
                                      tracker_step = "Geocoding") {
-  if (!file.exists(file_path)) {
-    stop("Input file not found.")
+  checkmate::assert_string(file_path, min.chars = 1, any.missing = FALSE)
+  checkmate::assert_file_exists(file_path)
+  checkmate::assert_string(google_maps_api_key, min.chars = 1, any.missing = FALSE)
+  checkmate::assert_flag(notify)
+  checkmate::assert_flag(quiet)
+  checkmate::assert_string(tracker_step, min.chars = 1, any.missing = FALSE)
+  if (!is.null(output_file_path)) {
+    checkmate::assert_string(output_file_path, min.chars = 1, any.missing = FALSE)
+  }
+  if (!is.null(failed_output_path)) {
+    checkmate::assert_string(failed_output_path, min.chars = 1, any.missing = FALSE)
   }
 
   # Read input based on extension
@@ -53,9 +62,8 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
                  xlsx = readxl::read_excel(file_path),
                  stop("Unsupported file type: ", ext))
 
-  if (!"address" %in% names(data)) {
-    stop("The dataset must have a column named 'address' for geocoding.")
-  }
+  checkmate::assert_data_frame(data, min.rows = 1)
+  checkmate::assert_names(names(data), must.include = "address")
 
   if (!requireNamespace("ggmap", quietly = TRUE)) {
     stop("Package 'ggmap' is required for geocode_unique_addresses(). Install with: install.packages('ggmap')", call. = FALSE)

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -49,9 +49,11 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
   checkmate::assert_string(tracker_step, min.chars = 1, any.missing = FALSE)
   if (!is.null(output_file_path)) {
     checkmate::assert_string(output_file_path, min.chars = 1, any.missing = FALSE)
+    checkmate::assert_true(dirname(output_file_path) != "", .var.name = "output_file_path directory")
   }
   if (!is.null(failed_output_path)) {
     checkmate::assert_string(failed_output_path, min.chars = 1, any.missing = FALSE)
+    checkmate::assert_true(dirname(failed_output_path) != "", .var.name = "failed_output_path directory")
   }
 
   # Read input based on extension
@@ -64,6 +66,8 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
 
   checkmate::assert_data_frame(data, min.rows = 1)
   checkmate::assert_names(names(data), must.include = "address")
+  checkmate::assert_true(all(!is.na(data$address)), .var.name = "address has no missing values")
+  checkmate::assert_true(all(trimws(data$address) != ""), .var.name = "address has no blank values")
 
   if (!requireNamespace("ggmap", quietly = TRUE)) {
     stop("Package 'ggmap' is required for geocode_unique_addresses(). Install with: install.packages('ggmap')", call. = FALSE)
@@ -72,6 +76,8 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
 
   unique_add <- dplyr::distinct(data, address)
   total_unique <- nrow(unique_add)
+  checkmate::assert_int(total_unique, lower = 0)
+  checkmate::assert_true(total_unique <= nrow(data), .var.name = "unique address count")
   tyler_log_info(sprintf("Geocoding %d unique address(es).", total_unique), quiet = quiet)
 
   # Comprehensive logging: show what we're about to do
@@ -131,6 +137,11 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
         coords <- attempt_result
 
         # Validate geocoding result structure immediately (Bug #11 fix)
+        checkmate::assert_true(length(coords$lat) == nrow(coords), .var.name = "lat length")
+        checkmate::assert_true(length(coords$lon) == nrow(coords), .var.name = "lon length")
+  checkmate::assert_number(success_rate, lower = 0, upper = 1)
+  checkmate::assert_int(success_count, lower = 0)
+  checkmate::assert_true(success_count <= total_unique, .var.name = "success_count bound")
         if (!is.data.frame(coords)) {
           stop("Geocoding API returned unexpected data type (expected data frame).")
         }


### PR DESCRIPTION
### Motivation
- Fail fast and provide clearer errors for the geocoding step by validating function arguments and input structure before performing costly API calls.

### Description
- Add `checkmate` assertions to `geocode_unique_addresses()` to validate `file_path` (non-empty and exists), `google_maps_api_key` (non-empty), logical flags `notify` and `quiet`, `tracker_step`, optional `output_file_path`/`failed_output_path`, and to assert the loaded input is a non-empty data frame that includes an `address` column, and add `checkmate` to `DESCRIPTION` imports.

### Testing
- Attempted an automated parse check via `R -q -e "parse(file='R/geocode.R'); parse(file='R/utils-validation.R')"`, but the environment does not have `R` installed (`R: command not found`), so no R-based automated checks were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8548118c832cb0fb692e180b979a)