### PR TITLE
Add checkmate validation to NPI input checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     RColorBrewer,
     arsenal,
     broom,
+    checkmate,
     data.table,
     dplyr,
     emmeans,

--- a/R/search_and_process_npi.R
+++ b/R/search_and_process_npi.R
@@ -62,25 +62,18 @@ search_and_process_npi <- function(data,
                                    progress_callback = NULL,
                                    heartbeat_seconds = NULL,
                                    progress_log_format = c("text", "csv")) {
-  if (!is.data.frame(data)) {
-    stop("Input 'data' must be a data frame.")
-  }
+  validate_dataframe(data, name = "data")
 
   progress_log_format <- match.arg(progress_log_format)
-  if (!is.null(heartbeat_seconds)) {
-    if (!is.numeric(heartbeat_seconds) || length(heartbeat_seconds) != 1L ||
-        is.na(heartbeat_seconds) || heartbeat_seconds <= 0) {
-      stop("`heartbeat_seconds` must be a single positive numeric value or NULL.")
-    }
-  }
+  validate_scalar_positive_numeric(
+    heartbeat_seconds,
+    name = "heartbeat_seconds",
+    allow_null = TRUE
+  )
 
   table_format <- tyler_normalize_file_format(file_format, path = accumulate_path)
 
-  required_cols <- c("first", "last")
-  missing_cols <- setdiff(required_cols, names(data))
-  if (length(missing_cols)) {
-    stop("Input data must contain columns: ", paste(missing_cols, collapse = ", "))
-  }
+  validate_required_columns(data, required = c("first", "last"), name = "data")
 
   # Validate that required columns contain actual data, not all NA (Bug #7 fix)
   if (nrow(data) > 0) {

--- a/R/utils-validation.R
+++ b/R/utils-validation.R
@@ -10,6 +10,9 @@
 #'
 #' @keywords internal
 validate_dataframe <- function(x, name = "data", allow_null = FALSE, allow_zero_rows = TRUE) {
+  checkmate::assert_string(name, min.chars = 1, .var.name = "name")
+  checkmate::assert_flag(allow_null, .var.name = "allow_null")
+  checkmate::assert_flag(allow_zero_rows, .var.name = "allow_zero_rows")
   if (is.null(x)) {
     if (allow_null) {
       return(invisible(x))
@@ -31,6 +34,8 @@ validate_dataframe <- function(x, name = "data", allow_null = FALSE, allow_zero_
 
 #' @keywords internal
 validate_scalar_positive_numeric <- function(x, name, allow_null = TRUE) {
+  checkmate::assert_string(name, min.chars = 1, .var.name = "name")
+  checkmate::assert_flag(allow_null, .var.name = "allow_null")
   if (is.null(x)) {
     if (allow_null) {
       return(invisible(x))
@@ -51,6 +56,9 @@ validate_scalar_positive_numeric <- function(x, name, allow_null = TRUE) {
 
 #' @keywords internal
 validate_required_columns <- function(x, required, name = "data") {
+  checkmate::assert_data_frame(x, .var.name = "x")
+  checkmate::assert_character(required, null.ok = TRUE, any.missing = FALSE, .var.name = "required")
+  checkmate::assert_string(name, min.chars = 1, .var.name = "name")
   if (is.null(required) || !length(required)) {
     return(invisible(x))
   }

--- a/R/utils-validation.R
+++ b/R/utils-validation.R
@@ -28,6 +28,27 @@ validate_dataframe <- function(x, name = "data", allow_null = FALSE, allow_zero_
   invisible(x)
 }
 
+
+#' @keywords internal
+validate_scalar_positive_numeric <- function(x, name, allow_null = TRUE) {
+  if (is.null(x)) {
+    if (allow_null) {
+      return(invisible(x))
+    }
+    stop(sprintf("`%s` must not be NULL.", name), call. = FALSE)
+  }
+
+  checkmate::assert_number(
+    x,
+    lower = 0,
+    finite = TRUE,
+    na.ok = FALSE,
+    .var.name = name
+  )
+
+  invisible(x)
+}
+
 #' @keywords internal
 validate_required_columns <- function(x, required, name = "data") {
   if (is.null(required) || !length(required)) {


### PR DESCRIPTION
### Motivation
- Standardize and centralize input validation for NPI search code paths to reduce duplicated checks and produce consistent error messages.

### Description
- Add `checkmate` to package `Imports` in `DESCRIPTION` to enable robust assertion helpers.  
- Introduce a new internal helper `validate_scalar_positive_numeric()` in `R/utils-validation.R` that calls `checkmate::assert_number()` to validate scalar, finite, non-missing, non-negative numerics.  
- Replace ad-hoc local validation in `search_and_process_npi()` with shared validators by calling `validate_dataframe()`, `validate_required_columns()` and `validate_scalar_positive_numeric()` and keeping existing data-cleaning behavior.  
- Changed files: `DESCRIPTION`, `R/utils-validation.R`, and `R/search_and_process_npi.R`.

### Testing
- Attempted to run the NPI search tests via `Rscript -e "testthat::test_file('tests/testthat/test-search_and_process_npi.R')"`, but the command could not execute because `Rscript` is not available in this environment. (No automated tests completed successfully.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa858d78cc832c96de36275665d738)