### PR TITLE
Add checkmate validation to block-group overlap mapper

### DIFF
--- a/R/map_create_block_group_overlap.R
+++ b/R/map_create_block_group_overlap.R
@@ -19,7 +19,7 @@
 #' }
 #'
 #' @importFrom dplyr arrange mutate
-#' @importFrom checkmate assert_class assert_string
+#' @importFrom checkmate assert_class assert_string assert_numeric
 #' @importFrom htmlwidgets saveWidget
 #' @importFrom sf st_make_valid st_transform st_is_valid st_union st_sf
 #' @importFrom lwgeom st_orient
@@ -35,6 +35,21 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
   checkmate::assert_class(bg_data, "sf", .var.name = "bg_data")
   checkmate::assert_class(isochrones_data, "sf", .var.name = "isochrones_data")
   checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_numeric(
+    bg_data$overlap,
+    lower = 0,
+    upper = 1,
+    any.missing = FALSE,
+    finite = TRUE,
+    .var.name = "bg_data$overlap"
+  )
+  checkmate::assert_numeric(
+    suppressWarnings(as.numeric(isochrones_data$drive_time)),
+    lower = 0,
+    any.missing = FALSE,
+    finite = TRUE,
+    .var.name = "drive_time"
+  )
 
   validated <- validate_sf_inputs(
     bg_data = bg_data,


### PR DESCRIPTION
### Motivation
- Fail-fast input validation for the block-group overlap mapper was missing numeric checks that tests expect, so explicit assertions are needed to surface user errors early.
- These checks align function behaviour with existing validation tests that assert on `bg_data$overlap` and `isochrones` `drive_time` types/values.

### Description
- Add `checkmate::assert_numeric(bg_data$overlap, lower = 0, upper = 1, any.missing = FALSE, finite = TRUE, .var.name = "bg_data$overlap")` in `map_create_block_group_overlap()` to ensure overlap values are finite and within [0,1].
- Add `checkmate::assert_numeric(suppressWarnings(as.numeric(isochrones_data$drive_time)), lower = 0, any.missing = FALSE, finite = TRUE, .var.name = "drive_time")` to ensure `drive_time` is numeric and non-negative before downstream processing.
- Update roxygen `@importFrom checkmate` to include `assert_numeric` and place the new assertions prior to `validate_sf_inputs()` so invalid inputs fail fast.

### Testing
- Attempted to run the overlap validation unit test `tests/testthat/test-overlap-checkmate-validations.R` via `Rscript -e "testthat::test_file('tests/testthat/test-overlap-checkmate-validations.R')"`, but `Rscript` is not available in this environment so the automated test could not be executed.
- No automated tests were run to completion in this environment; changes were validated by static inspection of the modified file and the test expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9196f358832c92b5bee79c66f5f4)