### PR TITLE
Add workflow_summary tibble to run_mystery_caller_workflow for transparency

### DIFF
--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -43,7 +43,9 @@
 #'
 #' @return A list containing intermediate artefacts from each workflow stage:
 #'   `roster`, `validated_roster`, `cleaned_phase1`, `cleaned_phase2`,
-#'   `coverage_summary`, and `quality_check_table`.
+#'   `coverage_summary`, `quality_check_table`, and a `workflow_summary` data
+#'   frame documenting row counts, retention rates, and output paths for audit
+#'   transparency.
 #'
 #' @export
 #' @importFrom dplyr bind_rows distinct
@@ -253,7 +255,44 @@ run_mystery_caller_workflow <- function(
     quality_check_table <- save_quality_check_table(cleaned_phase2, quality_check_path)
   }
 
+  workflow_summary <- tibble::tibble(
+    stage = c(
+      "combined_roster",
+      "validated_roster",
+      "cleaned_phase1",
+      "cleaned_phase2",
+      "coverage_summary",
+      "quality_check_table"
+    ),
+    n_rows = c(
+      nrow(combined_roster),
+      nrow(validated_roster),
+      nrow(cleaned_phase1),
+      nrow(cleaned_phase2),
+      if (is.null(coverage_summary)) NA_integer_ else nrow(coverage_summary),
+      if (is.null(quality_check_table)) NA_integer_ else nrow(quality_check_table)
+    ),
+    retention_from_previous = c(
+      NA_real_,
+      if (nrow(combined_roster) == 0) NA_real_ else nrow(validated_roster) / nrow(combined_roster),
+      if (nrow(validated_roster) == 0) NA_real_ else nrow(cleaned_phase1) / nrow(validated_roster),
+      if (nrow(cleaned_phase1) == 0) NA_real_ else nrow(cleaned_phase2) / nrow(cleaned_phase1),
+      if (is.null(coverage_summary) || nrow(cleaned_phase2) == 0) NA_real_ else nrow(coverage_summary) / nrow(cleaned_phase2),
+      if (is.null(quality_check_table) || nrow(cleaned_phase2) == 0) NA_real_ else nrow(quality_check_table) / nrow(cleaned_phase2)
+    ),
+    output_path = c(
+      NA_character_,
+      NA_character_,
+      phase1_output_directory,
+      phase2_output_directory,
+      NA_character_,
+      quality_check_path
+    )
+  )
+
   if (isTRUE(verbose)) {
+    message("Workflow summary (rows and retention):")
+    print(workflow_summary)
     message(sprintf("[%s] Mystery caller workflow complete", format(Sys.time(), "%H:%M:%S")))
   }
 
@@ -263,6 +302,7 @@ run_mystery_caller_workflow <- function(
     cleaned_phase1 = cleaned_phase1,
     cleaned_phase2 = cleaned_phase2,
     coverage_summary = coverage_summary,
-    quality_check_table = quality_check_table
+    quality_check_table = quality_check_table,
+    workflow_summary = workflow_summary
   )
 }

--- a/man/run_mystery_caller_workflow.Rd
+++ b/man/run_mystery_caller_workflow.Rd
@@ -10,6 +10,7 @@ run_mystery_caller_workflow(
   lab_assistant_names,
   output_directory,
   phase2_data,
+  phase2_output_directory = output_directory,
   quality_check_path,
   phase1_output_directory = output_directory,
   split_insurance_order = c("Medicaid", "Blue Cross/Blue Shield"),
@@ -44,6 +45,8 @@ run_mystery_caller_workflow(
 
 \item{phase2_data}{Data frame or file path consumed by \code{clean_phase_2_data()}.}
 
+\item{phase2_output_directory}{Directory where Phase 2 exports should be written. Defaults to \code{output_directory}.}
+
 \item{quality_check_path}{File path where \code{save_quality_check_table()} should write the quality check CSV.}
 
 \item{phase1_output_directory}{Directory where \code{clean_phase_1_results()} should write the cleaned Phase 1 CSV. Defaults to \code{output_directory}.}
@@ -63,7 +66,7 @@ run_mystery_caller_workflow(
 \item{npi_progress_observer}{Optional callback that receives progress updates from \code{search_and_process_npi()}. It is invoked with the same payload as that function's \code{progress_callback} argument.}
 }
 \value{
-A list containing intermediate artefacts from each workflow stage: \code{roster}, \code{validated_roster}, \code{cleaned_phase1}, \code{cleaned_phase2}, \code{coverage_summary}, and \code{quality_check_table}.
+A list containing intermediate artefacts from each workflow stage: \code{roster}, \code{validated_roster}, \code{cleaned_phase1}, \code{cleaned_phase2}, \code{coverage_summary}, \code{quality_check_table}, and a \code{workflow_summary} data frame documenting row counts, retention rates, and output paths for audit transparency.
 }
 \description{
 This helper orchestrates the core steps required to prepare and execute a mystery caller campaign. It stitches together roster creation, NPI validation, call sheet preparation, workload splitting, and Phase 2 hygiene checks so teams can focus on execution instead of plumbing.


### PR DESCRIPTION
### Motivation
- Improve data transparency and auditability by exposing per-stage row counts and retention so users can quickly detect where records are lost or filtered during the mystery caller pipeline.

### Description
- Added a `workflow_summary` tibble to `run_mystery_caller_workflow()` that records `stage`, `n_rows`, `retention_from_previous`, and `output_path` for the stages `combined_roster`, `validated_roster`, `cleaned_phase1`, `cleaned_phase2`, `coverage_summary`, and `quality_check_table` in `R/run_mystery_caller_workflow.R`.
- Emit the `workflow_summary` to the console when `verbose = TRUE` so users see a printed summary before the final completion message, and return the `workflow_summary` as part of the function result.
- Updated the function usage and documentation in `man/run_mystery_caller_workflow.Rd` to include the existing `phase2_output_directory` argument in the signature and to document the new `workflow_summary` return component.

### Testing
- Attempted to parse the modified R file with `Rscript -e "parse(file='R/run_mystery_caller_workflow.R')"`, but the check failed because `Rscript` is not installed in this environment (automated parse could not be executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa917e1df0832c85e7976dc8c99c0c)