### PR TITLE
Add input validation, logging fixes, and workflow robustness

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -137,11 +137,6 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
         coords <- attempt_result
 
         # Validate geocoding result structure immediately (Bug #11 fix)
-        checkmate::assert_true(length(coords$lat) == nrow(coords), .var.name = "lat length")
-        checkmate::assert_true(length(coords$lon) == nrow(coords), .var.name = "lon length")
-  checkmate::assert_number(success_rate, lower = 0, upper = 1)
-  checkmate::assert_int(success_count, lower = 0)
-  checkmate::assert_true(success_count <= total_unique, .var.name = "success_count bound")
         if (!is.data.frame(coords)) {
           stop("Geocoding API returned unexpected data type (expected data frame).")
         }
@@ -151,6 +146,9 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
             paste(names(coords), collapse = ", ")
           ))
         }
+        checkmate::assert_true(length(coords$lat) == nrow(coords), .var.name = "lat length")
+        checkmate::assert_true(length(coords$lon) == nrow(coords), .var.name = "lon length")
+
         if (nrow(coords) != total_unique) {
           warning(sprintf(
             "Geocoding returned %d rows but expected %d. Some addresses may be missing results.",
@@ -171,6 +169,9 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
   failed_rows <- unique_add[!stats::complete.cases(unique_add[, c("latitude", "longitude")]), , drop = FALSE]
   success_rate <- if (total_unique) 1 - nrow(failed_rows) / total_unique else 1
   success_count <- total_unique - nrow(failed_rows)
+  checkmate::assert_number(success_rate, lower = 0, upper = 1)
+  checkmate::assert_int(success_count, lower = 0)
+  checkmate::assert_true(success_count <= total_unique, .var.name = "success_count bound")
 
   # Comprehensive logging: Report geocoding results
   if (!quiet) {

--- a/R/preflight_checks.R
+++ b/R/preflight_checks.R
@@ -51,6 +51,11 @@ tyler_preflight_check <- function(input_data,
                                    interactive = interactive(),
                                    required_columns = c("first", "last")) {
 
+  checkmate::assert_flag(check_apis)
+  checkmate::assert_flag(estimate_resources)
+  checkmate::assert_flag(interactive)
+  checkmate::assert_character(required_columns, any.missing = FALSE)
+
   message("")
   message("\u256D", strrep("\u2500", 58), "\u256E")
   message("\u2502", "   Tyler Package - Preflight Check", strrep(" ", 23), "\u2502")
@@ -145,16 +150,21 @@ tyler_preflight_check <- function(input_data,
   message("")
   message("\U0001F511 Checking API keys...")
 
+  google_ok <- FALSE
+  here_ok <- FALSE
+
   if (!is.null(google_maps_api_key) && nzchar(google_maps_api_key)) {
     if (check_apis) {
       google_check <- tyler_validate_google_api(google_maps_api_key)
       if (google_check$valid) {
         message("  \u2713 Google Maps API key valid")
+        google_ok <- TRUE
       } else {
         errors <- c(errors, sprintf("Google Maps API key invalid: %s", google_check$error))
       }
     } else {
       message("  \u2713 Google Maps API key provided (not tested)")
+      google_ok <- TRUE
     }
   } else {
     warnings <- c(warnings, "No Google Maps API key provided (geocoding will fail)")
@@ -165,17 +175,19 @@ tyler_preflight_check <- function(input_data,
       here_check <- tyler_validate_here_api(here_api_key)
       if (here_check$valid) {
         message("  \u2713 HERE API key valid")
+        here_ok <- TRUE
       } else {
         errors <- c(errors, sprintf("HERE API key invalid: %s", here_check$error))
       }
     } else {
       message("  \u2713 HERE API key provided (not tested)")
+      here_ok <- TRUE
     }
   } else {
     warnings <- c(warnings, "No HERE API key provided (isochrones will fail)")
   }
 
-  checks$api_keys <- length(errors) == 0
+  checks$api_keys <- google_ok && here_ok
 
   # ==================== Check 5: Data Quality ====================
   message("")
@@ -407,6 +419,10 @@ tyler_assess_data_quality <- function(data, required_columns = c("first", "last"
   issues <- list()
   penalties <- 0
   max_penalties <- 10
+
+  if (!nrow(data)) {
+    return(list(score = 0, issues = list(list(severity = "error", message = "Input data has zero rows")), penalties = max_penalties))
+  }
 
   # Check for missing values in required columns
   for (col in required_columns) {

--- a/R/run_mystery_caller_workflow_with_logging.R
+++ b/R/run_mystery_caller_workflow_with_logging.R
@@ -58,6 +58,13 @@ run_mystery_caller_workflow_with_logging <- function(input_data,
                                                       log_file = NULL,
                                                       skip_preflight = FALSE) {
 
+  checkmate::assert_string(output_dir, min.chars = 1, any.missing = FALSE)
+  checkmate::assert_flag(skip_preflight)
+  checkmate::assert_numeric(drive_time_minutes, any.missing = FALSE, min.len = 1)
+  checkmate::assert_true(all(is.finite(drive_time_minutes)), .var.name = "drive_time_minutes finite")
+  checkmate::assert_true(all(drive_time_minutes > 0), .var.name = "drive_time_minutes positive")
+  drive_time_minutes <- sort(unique(as.integer(round(drive_time_minutes))))
+
   # ==================== PREFLIGHT CHECKS ====================
   # Run comprehensive validation before starting workflow
   if (!skip_preflight) {
@@ -88,9 +95,11 @@ run_mystery_caller_workflow_with_logging <- function(input_data,
   }
 
   # Initialize workflow tracking
+  total_steps <- 4 + length(drive_time_minutes)
+
   tyler_workflow_start(
     workflow_name = "Mystery Caller Workflow",
-    total_steps = 5,
+    total_steps = total_steps,
     log_file = log_file
   )
 
@@ -124,7 +133,6 @@ run_mystery_caller_workflow_with_logging <- function(input_data,
       notify = FALSE
     )
 
-    success_rate_npi <- nrow(npi_results) / input_n
     tyler_log_step_complete(
       n_success = nrow(npi_results),
       n_total = input_n
@@ -150,8 +158,14 @@ run_mystery_caller_workflow_with_logging <- function(input_data,
   )
 
   tryCatch({
+    npi_input_path <- file.path(output_dir, "npi_accumulated.csv")
+    if (!file.exists(npi_input_path)) {
+      npi_input_path <- file.path(output_dir, "npi_for_geocoding.csv")
+      tyler_write_table(data, npi_input_path)
+    }
+
     geocoded_data <- geocode_unique_addresses(
-      file_path = file.path(output_dir, "npi_accumulated.csv"),
+      file_path = npi_input_path,
       google_maps_api_key = google_maps_api_key,
       output_file_path = file.path(output_dir, "geocoded_physicians.csv"),
       failed_output_path = file.path(output_dir, "geocoding_failures.csv"),

--- a/R/utils-logging.R
+++ b/R/utils-logging.R
@@ -247,11 +247,11 @@ tyler_log_cache_hit <- function(what, n_items) {
 #' @export
 tyler_log_save <- function(path, n_rows = NULL) {
   if (!is.null(n_rows)) {
-    msg <- sprintf("  \u1F4BE Saved to: %s (%s rows)",
+    msg <- sprintf("  \U0001F4BE Saved to: %s (%s rows)",
                    path,
                    format(n_rows, big.mark = ","))
   } else {
-    msg <- sprintf("  \u1F4BE Saved to: %s", path)
+    msg <- sprintf("  \U0001F4BE Saved to: %s", path)
   }
   message(msg)
   tyler_log_to_file(msg)
@@ -399,7 +399,7 @@ tyler_format_duration <- function(seconds) {
 tyler_log_to_file <- function(msg) {
   if (!is.null(.tyler_workflow$log_file)) {
     # Remove ANSI codes and special characters for file logging
-    clean_msg <- gsub("\u2713|\u2717|\u26A0|\u2139|\u25B6|\u25B8|\u21BB|\u1F4BE", "", msg)
+    clean_msg <- gsub("\u2713|\u2717|\u26A0|\u2139|\u25B6|\u25B8|\u21BB|\U0001F4BE", "", msg)
     lock_path <- paste0(.tyler_workflow$log_file, ".lock")
     lock_acquired <- FALSE
     for (i in seq_len(100)) {


### PR DESCRIPTION
### Motivation
- Improve robustness by validating inputs and API responses early to avoid silent failures or cryptic errors.
- Make workflow step counting and geocoding input selection dynamic so the runner handles varied `drive_time_minutes` and missing intermediate files.
- Fix logging issues related to Unicode handling and ensure saved/logged messages are consistent and lock-safe.
- Harden data-quality assessment to handle empty inputs gracefully.

### Description
- Added argument and state checks with `checkmate` in `run_mystery_caller_workflow_with_logging.R` for `output_dir`, `skip_preflight`, and `drive_time_minutes`, normalized `drive_time_minutes` to sorted unique integer minutes, and computed `total_steps` dynamically before calling `tyler_workflow_start`.
- Made geocoding input selection resilient by checking for `npi_accumulated.csv` and writing `npi_for_geocoding.csv` if needed, and passed that path into `geocode_unique_addresses`.
- In `R/geocode.R`, validated the geocoding API result structure before use and restored/moved `checkmate` assertions to ensure `coords$lat`/`coords$lon` lengths and to assert `success_rate` and `success_count` bounds after computing failures.
- In `R/preflight_checks.R`, added `checkmate` assertions for flags and `required_columns`, introduced `google_ok` and `here_ok` booleans and set `checks$api_keys` to `google_ok && here_ok`, and added an early return in `tyler_assess_data_quality` when input `data` has zero rows.
- Fixed Unicode handling in `R/utils-logging.R` by replacing incorrect escape usage with `\U0001F4BE` in message formatting and the `gsub` pattern so log file outputs are cleaned correctly.

### Testing
- Ran package unit tests with `devtools::test()` and no test failures were reported.
- Performed package checks with `devtools::check()` (R CMD check) and the run completed without errors or NOTE-level regressions related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8db080bc832c8083b070230c469a)