### PR TITLE
Move quiet-logging toggle into logging module and add duplicate-functions report

### DIFF
--- a/DUPLICATE_FUNCTIONS_REPORT.md
+++ b/DUPLICATE_FUNCTIONS_REPORT.md
@@ -1,0 +1,78 @@
+# Duplicate Function Definitions Report
+
+Generated on 2026-05-06 (UTC).
+
+- Total unique function names scanned: 189
+- Function names with duplicates: 11
+
+## `announce` (2 definitions)
+- `R/clean_phase_1_results.R:95`
+- `R/run_mystery_caller_workflow.R:80`
+
+## `create_temp_csv` (3 definitions)
+- `tests/testthat/test-get_clinician_data.R:14`
+- `tests/testthat/test-geocode.R:25`
+- `tests/testthat/test-search_and_process_npi.R:74`
+
+## `extract_status` (3 definitions)
+- `R/search_by_taxonomy.R:127`
+- `R/search_and_process_npi.R:272`
+- `R/geocode.R:92`
+
+## `fake_genderize` (5 definitions)
+- `tests/testthat/test-genderize_physicians.R:153`
+- `tests/testthat/test-genderize_physicians.R:183`
+- `tests/testthat/test-genderize_physicians.R:213`
+- `tests/testthat/test-genderize_physicians.R:243`
+- `tests/testthat/test-genderize_physicians.R:270`
+
+## `fake_get` (3 definitions)
+- `tests/testthat/test-genderize_physicians.R:38`
+- `tests/testthat/test-genderize_physicians.R:66`
+- `tests/testthat/test-genderize_physicians.R:114`
+
+## `fn` (7 definitions)
+- `tests/testthat/test-progress-bars.R:303`
+- `tests/testthat/test-progress-bars.R:313`
+- `tests/testthat/test-progress-bars.R:328`
+- `tests/testthat/test-progress-bars.R:343`
+- `tests/testthat/test-progress-bars.R:356`
+- `tests/testthat/test-progress-bars.R:526`
+- `tests/testthat/test-progress-bars.R:602`
+
+## `mock_geocode` (2 definitions)
+- `tests/testthat/test-vignette-handoffs.R:236`
+- `tests/testthat/test-geocode.R:12`
+
+## `mock_get_census` (3 definitions)
+- `tests/testthat/test-integration-database.R:110`
+- `tests/testthat/test-end-to-end-workflow.R:243`
+- `tests/testthat/test-vignette-handoffs.R:142`
+
+## `mock_npi_flatten` (10 definitions)
+- `tests/testthat/test-regression-match-rates.R:88`
+- `tests/testthat/test-integration-database.R:70`
+- `tests/testthat/test-search-by-taxonomy-comprehensive.R:27`
+- `tests/testthat/test-end-to-end-workflow.R:171`
+- `tests/testthat/test-performance-benchmarks.R:160`
+- `tests/testthat/test-vignette-handoffs.R:52`
+- `tests/testthat/test-vignette-handoffs.R:317`
+- `tests/testthat/test-vignette-handoffs.R:374`
+- `tests/testthat/test-search_and_process_npi.R:60`
+- `tests/testthat/test-property-based.R:235`
+
+## `mock_npi_search` (9 definitions)
+- `tests/testthat/test-regression-match-rates.R:64`
+- `tests/testthat/test-integration-database.R:63`
+- `tests/testthat/test-search-by-taxonomy-comprehensive.R:8`
+- `tests/testthat/test-end-to-end-workflow.R:142`
+- `tests/testthat/test-performance-benchmarks.R:147`
+- `tests/testthat/test-vignette-handoffs.R:34`
+- `tests/testthat/test-vignette-handoffs.R:303`
+- `tests/testthat/test-search_and_process_npi.R:17`
+- `tests/testthat/test-property-based.R:218`
+
+## `search_npi` (2 definitions)
+- `R/deprecated.R:22`
+- `R/search_and_process_npi.R:284`
+

--- a/R/utility_library.R
+++ b/R/utility_library.R
@@ -246,32 +246,6 @@ tyler_export_with_backup <- function(x, path, backup = TRUE, quiet = getOption("
 # -------------------------------------------------------------------------
 # Quiet logging -----------------------------------------------------------
 
-#' Toggle quiet logging for helper functions
-#'
-#' @param quiet Logical flag. When `TRUE`, suppress messages emitted by
-#'   `tyler_log_info()`.
-#'
-#' @return The previous quiet value (invisibly).
-#' @export
-tyler_use_quiet_logging <- function(quiet = TRUE) {
-  old <- getOption("tyler.quiet", FALSE)
-  options(tyler.quiet = quiet)
-  invisible(old)
-}
-
-#' Emit a timestamped log message when quiet mode is disabled
-#'
-#' @param message_text Character string to print.
-#' @param quiet Optional override for quiet behaviour.
-#'
-#' @export
-tyler_log_info <- function(message_text, quiet = getOption("tyler.quiet", FALSE)) {
-  if (!isTRUE(quiet)) {
-    message(sprintf("[%s] %s", format(Sys.time(), "%H:%M:%S"), message_text))
-  }
-  invisible(NULL)
-}
-
 # -------------------------------------------------------------------------
 # Standard labels and palettes -------------------------------------------
 

--- a/R/utils-logging.R
+++ b/R/utils-logging.R
@@ -455,3 +455,17 @@ tyler_progress_callback <- function(total, label = "Processing") {
     }
   }
 }
+
+
+#' Toggle quiet logging for helper functions
+#'
+#' @param quiet Logical flag. When `TRUE`, suppress messages emitted by
+#'   `tyler_log_info()` when using quiet-aware wrappers.
+#'
+#' @return The previous quiet value (invisibly).
+#' @export
+tyler_use_quiet_logging <- function(quiet = TRUE) {
+  old <- getOption("tyler.quiet", FALSE)
+  options(tyler.quiet = quiet)
+  invisible(old)
+}


### PR DESCRIPTION
### Motivation

- Consolidate logging-related utilities into the logging module to keep logging helpers together and reduce duplication in `R/utility_library.R`.
- Remove an unused/duplicated logger helper from the utility library to clarify the public API surface.
- Add a generated report documenting duplicate function definitions found across the repository to aid cleanup and test hygiene.

### Description

- Moved the `tyler_use_quiet_logging` function from `R/utility_library.R` into `R/utils-logging.R` and kept its behaviour and export intact.
- Removed the `tyler_log_info` helper from `R/utility_library.R` (no replacement added in this change).
- Added `DUPLICATE_FUNCTIONS_REPORT.md`, a generated summary of duplicate function definitions across the codebase with counts and file locations.
- Minor formatting/whitespace adjustments around the moved function in `R/utils-logging.R`.

### Testing

- Ran the package unit tests via `devtools::test()` (the `testthat` suite); the test suite completed successfully.
- Executed `R CMD check` on the package to validate package structure and exports; no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8d5568c8832cb62a68664eaffa47)