### PR TITLE
Fix geocode and table-generation validation regressions

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -137,11 +137,6 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
         coords <- attempt_result
 
         # Validate geocoding result structure immediately (Bug #11 fix)
-        checkmate::assert_true(length(coords$lat) == nrow(coords), .var.name = "lat length")
-        checkmate::assert_true(length(coords$lon) == nrow(coords), .var.name = "lon length")
-  checkmate::assert_number(success_rate, lower = 0, upper = 1)
-  checkmate::assert_int(success_count, lower = 0)
-  checkmate::assert_true(success_count <= total_unique, .var.name = "success_count bound")
         if (!is.data.frame(coords)) {
           stop("Geocoding API returned unexpected data type (expected data frame).")
         }
@@ -150,6 +145,20 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
             "Geocoding API returned unexpected structure. Expected 'lat' and 'lon' columns, got: %s",
             paste(names(coords), collapse = ", ")
           ))
+        }
+        checkmate::assert_true(length(coords$lat) == nrow(coords), .var.name = "lat length")
+        checkmate::assert_true(length(coords$lon) == nrow(coords), .var.name = "lon length")
+        checkmate::assert_numeric(coords$lat, any.missing = TRUE, finite = FALSE, .var.name = "coords$lat")
+        checkmate::assert_numeric(coords$lon, any.missing = TRUE, finite = FALSE, .var.name = "coords$lon")
+        invalid_coord_rows <- which((!is.na(coords$lat) & (coords$lat < -90 | coords$lat > 90)) |
+                                      (!is.na(coords$lon) & (coords$lon < -180 | coords$lon > 180)))
+        if (length(invalid_coord_rows)) {
+          warning(sprintf(
+            "Geocoding returned %d row(s) with out-of-bounds coordinates; setting those results to NA.",
+            length(invalid_coord_rows)
+          ))
+          coords$lat[invalid_coord_rows] <- NA_real_
+          coords$lon[invalid_coord_rows] <- NA_real_
         }
         if (nrow(coords) != total_unique) {
           warning(sprintf(
@@ -171,6 +180,8 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
   failed_rows <- unique_add[!stats::complete.cases(unique_add[, c("latitude", "longitude")]), , drop = FALSE]
   success_rate <- if (total_unique) 1 - nrow(failed_rows) / total_unique else 1
   success_count <- total_unique - nrow(failed_rows)
+  checkmate::assert_number(success_rate, lower = 0, upper = 1, .var.name = "success_rate")
+  checkmate::assert_int(success_count, lower = 0, upper = total_unique, .var.name = "success_count")
 
   # Comprehensive logging: Report geocoding results
   if (!quiet) {
@@ -195,7 +206,7 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
   }
 
   if (!is.null(tracker) && inherits(tracker, "tyler_progress_tracker")) {
-    progress_tracker_finish(tracker, tracker_step, score = success_rate, note = sprintf("%d/%d succeeded", total_unique - nrow(failed_rows), total_unique))
+    progress_tracker_finish(tracker, tracker_step, score = success_rate, note = sprintf("%d/%d succeeded", success_count, total_unique))
   }
 
   data <- dplyr::left_join(data, unique_add, by = "address")

--- a/R/table_generate_overall.R
+++ b/R/table_generate_overall.R
@@ -71,10 +71,6 @@ table_generate_overall <- function(input_file_path, output_directory, title = "O
   cat("Reading data from file:", input_file_path, "\n")
   data <- readr::read_rds(input_file_path)
   checkmate::assert_data_frame(data, min.rows = 1, min.cols = 1)
-    checkmate::assert_subset(selected_columns, choices = names(data), empty.ok = FALSE)
-  checkmate::assert_data_frame(selected_data, min.rows = 1, min.cols = 1)
-    stop("The input data is empty.")
-  }
 
   # Check if selected_columns argument is provided
   if (is.null(selected_columns)) {
@@ -83,9 +79,12 @@ table_generate_overall <- function(input_file_path, output_directory, title = "O
     selected_data <- data
   } else {
     # If selected_columns is provided, select only those columns from the data
+    checkmate::assert_subset(selected_columns, choices = names(data), empty.ok = FALSE)
     cat("Selecting specific columns for the table: ", paste(selected_columns, collapse = ", "), "\n")
     selected_data <- data[, selected_columns, drop = FALSE]
   }
+
+  checkmate::assert_data_frame(selected_data, min.rows = 1, min.cols = 1)
 
   # Log data summary
   cat("Data summary:\n")


### PR DESCRIPTION
### Motivation
- Recent refactors introduced validation and control-flow regressions that could crash workflows when the geocoder returned unexpected results and when `table_generate_overall()` referenced `selected_data` before it was assigned.
- The changes aim to make geocoding defensive against malformed API responses and to ensure table generation validates arguments in the correct branch to avoid runtime errors.

### Description
- Reordered and hardened `R/geocode.R` so the response is checked for type and required `lat`/`lon` columns before dereferencing them, added numeric assertions for coordinates, and sanitised out-of-bounds coordinates to `NA` with a warning.
- Moved `success_rate`/`success_count` assertions to after those values are computed and updated the tracker completion note to use the computed `success_count`.
- Fixed `R/table_generate_overall.R` by removing an invalid early validation block, validating `selected_columns` only when provided, and asserting `selected_data` after the branch so the function cannot reference an unassigned variable.

### Testing
- Attempted to run the package test suite with `R -q -e 'devtools::test()'`, but the command failed because the `R` binary is not available in the execution environment so automated R tests could not be executed.
- Performed static/diff review and local file inspections to confirm the validation/control-flow issues were addressed (no automated R tests executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9165c288832c941c449ffe0ac541)