### PR TITLE
Harden data cleaning: character-safe random IDs, stricter validation, and safer column renaming

### DIFF
--- a/R/clean_phase_1_results.R
+++ b/R/clean_phase_1_results.R
@@ -215,20 +215,21 @@ clean_phase_1_results <- function(phase1_data,
 
   generate_random_ids <- function(n) {
     if (!n) {
-      return(numeric(0))
+      return(character(0))
     }
-    # Use timestamp + process ID for better uniqueness
-    base_time <- as.numeric(Sys.time())
+    # Use timestamp + process ID for better uniqueness.
+    # Keep IDs as character to avoid precision loss with large numeric values.
+    base_time <- format(Sys.time(), "%Y%m%d%H%M%S")
     process_id <- Sys.getpid()
-    unique_ids <- numeric(n)
+    unique_ids <- character(n)
 
     for (i in seq_len(n)) {
       # Combine timestamp, process ID, and counter to ensure uniqueness
-      unique_ids[i] <- as.numeric(paste0(
-        floor(base_time),
+      unique_ids[i] <- paste0(
+        base_time,
         sprintf("%05d", process_id %% 100000),
         sprintf("%03d", i)
-      ))
+      )
     }
     unique_ids
   }
@@ -239,7 +240,7 @@ clean_phase_1_results <- function(phase1_data,
       random_id = ifelse(
         is.na(npi),
         generate_random_ids(dplyr::n()),
-        npi
+        as.character(npi)
       ),
       processing_flag_generated_id = is.na(npi)
     )

--- a/R/clean_phase_2_results.R
+++ b/R/clean_phase_2_results.R
@@ -34,8 +34,18 @@
 #' print(df)
 rename_columns_by_substring <- function(data, target_strings, new_names) {
   # Initial checks and setup
+  validate_dataframe(data, name = "data")
+  checkmate::assert_character(target_strings, any.missing = FALSE, min.len = 1, .var.name = "target_strings")
+  checkmate::assert_character(new_names, any.missing = FALSE, min.len = 1, .var.name = "new_names")
+
   if (length(target_strings) != length(new_names)) {
     stop("target_strings and new_names must have the same length.")
+  }
+  if (any(!nzchar(trimws(target_strings)))) {
+    stop("`target_strings` cannot contain empty or whitespace-only entries.", call. = FALSE)
+  }
+  if (any(!nzchar(trimws(new_names)))) {
+    stop("`new_names` cannot contain empty or whitespace-only entries.", call. = FALSE)
   }
 
   message("--- Starting to search and rename columns based on target substrings ---")
@@ -43,23 +53,27 @@ rename_columns_by_substring <- function(data, target_strings, new_names) {
   rename_log <- list()
   rename_index <- 0L
   for (i in seq_along(target_strings)) {
-    target <- tolower(target_strings[i])
+    target <- tolower(trimws(target_strings[i]))
+    replacement <- trimws(new_names[i])
     normalized_names <- tolower(names(data))
 
     # Prefer exact case-insensitive matches first.
     matches <- normalized_names == target
     # Fall back to substring matching to preserve historical behavior and
     # prevent downstream column mismatch errors when callers pass patterns.
+    matched_by <- "exact"
     if (!any(matches)) {
       matches <- grepl(target, normalized_names, fixed = TRUE)
+      matched_by <- "substring"
     }
     matched_cols <- names(data)[matches]
 
     # Detailed log of what matches were found
     if (any(matches)) {
       message(sprintf(
-        "Matched %d column(s) exactly matching '%s': %s",
+        "Matched %d column(s) by %s match for '%s': %s",
         sum(matches),
+        matched_by,
         target_strings[i],
         paste(matched_cols, collapse = ", ")
       ))
@@ -72,18 +86,24 @@ rename_columns_by_substring <- function(data, target_strings, new_names) {
         ))
       }
       # Rename the matching column
-      names(data)[which(matches)[1]] <- new_names[i]
+      if (replacement %in% names(data) && replacement != matched_cols[1]) {
+        stop(sprintf(
+          "Cannot rename '%s' to '%s' because '%s' already exists.",
+          matched_cols[1], replacement, replacement
+        ), call. = FALSE)
+      }
+      names(data)[which(matches)[1]] <- replacement
       rename_index <- rename_index + 1L
       rename_log[[rename_index]] <- data.frame(
         pattern = target_strings[i],
         renamed_from = matched_cols[1],
-        renamed_to = new_names[i],
+        renamed_to = replacement,
         stringsAsFactors = FALSE
       )
       message(sprintf(
         "Renamed '%s' to '%s'.",
         matched_cols[1],
-        new_names[i]
+        replacement
       ))
     } else {
       warning(sprintf("No columns matched '%s'; nothing was renamed for this pattern.", target_strings[i]))
@@ -163,6 +183,9 @@ clean_phase_2_data <- function(
   }
   if (missing(standard_names) || !length(standard_names)) {
     stop("`standard_names` must supply at least one column name to apply.", call. = FALSE)
+  }
+  if (length(required_strings) != length(standard_names)) {
+    stop("`required_strings` and `standard_names` must have the same length.", call. = FALSE)
   }
 
   if (length(unique(standard_names)) != length(standard_names)) {

--- a/R/genderize_physicians.R
+++ b/R/genderize_physicians.R
@@ -114,6 +114,8 @@ genderize_physicians <- function(input_csv, output_dir = NULL, output_format = c
 }
 
 genderize_fetch <- function(first_names, batch_size = 10, api_url = "https://api.genderize.io/") {
+  checkmate::assert_count(batch_size, positive = TRUE, .var.name = "batch_size")
+  checkmate::assert_string(api_url, min.chars = 1, .var.name = "api_url")
   if (is.null(first_names) || length(first_names) == 0) {
     return(tibble::tibble(
       first_name = character(),
@@ -123,7 +125,8 @@ genderize_fetch <- function(first_names, batch_size = 10, api_url = "https://api
     ))
   }
 
-  clean_names <- unique(stats::na.omit(trimws(first_names)))
+  clean_names <- unique(stats::na.omit(trimws(as.character(first_names))))
+  clean_names <- clean_names[nzchar(clean_names)]
   if (length(clean_names) == 0) {
     return(tibble::tibble(
       first_name = character(),

--- a/R/search_by_taxonomy.R
+++ b/R/search_by_taxonomy.R
@@ -65,7 +65,12 @@ search_by_taxonomy <- function(taxonomy_to_search,
     return(tibble::tibble())
   }
 
-  taxonomy_to_search <- taxonomy_to_search[!is.na(taxonomy_to_search)]
+  checkmate::assert_flag(write_snapshot, .var.name = "write_snapshot")
+  checkmate::assert_flag(notify, .var.name = "notify")
+  checkmate::assert_number(limit, lower = 1, upper = 1200, finite = TRUE, .var.name = "limit")
+
+  taxonomy_to_search <- trimws(as.character(taxonomy_to_search))
+  taxonomy_to_search <- taxonomy_to_search[!is.na(taxonomy_to_search) & nzchar(taxonomy_to_search)]
   if (!length(taxonomy_to_search)) {
     return(tibble::tibble())
   }
@@ -73,7 +78,15 @@ search_by_taxonomy <- function(taxonomy_to_search,
   # When states are provided loop over each state so we bypass the 1200-record
   # per-query cap. Results are deduplicated on NPI before returning.
   if (!is.null(states) && length(states)) {
+    states <- toupper(trimws(as.character(states)))
     states <- unique(states[!is.na(states) & nzchar(states)])
+    invalid_states <- states[nchar(states) != 2]
+    if (length(invalid_states)) {
+      stop(sprintf(
+        "`states` must contain two-letter abbreviations. Invalid entries: %s",
+        paste(invalid_states, collapse = ", ")
+      ), call. = FALSE)
+    }
     message(sprintf(
       "Searching %d taxonomy term(s) across %d state(s) to bypass the 1200-record cap...",
       length(taxonomy_to_search), length(states)


### PR DESCRIPTION
### Motivation
- Prevent numeric precision loss and type inconsistencies when generating fallback IDs and when mixing original NPIs with generated values.  
- Improve robustness and error messaging for column renaming to avoid ambiguous or conflicting renames.  
- Harden input handling for name-gender lookups and taxonomy searches to avoid NA/empty entries and invalid arguments.

### Description
- Updated `generate_random_ids` to return character IDs, format timestamps as `"%Y%m%d%H%M%S"`, and ensure `random_id` is always character while preserving original `npi` in `clean_phase_1_results.R`.  
- Reworked `rename_columns_by_substring` in `clean_phase_2_results.R` to add input validation (`validate_dataframe`, `checkmate`), trim inputs, prefer exact matches, report whether a match was exact or substring, and prevent renaming collisions; attach a `rename_log` attribute.  
- Added checks in `clean_phase_2_data` to ensure `required_strings` and `standard_names` lengths match and integrated the improved renaming flow with messages.  
- Tightened `genderize_fetch` in `genderize_physicians.R` by validating `batch_size` and `api_url`, coercing `first_names` to character, removing empty names, and keeping batching logic.  
- Strengthened `search_by_taxonomy` in `search_by_taxonomy.R` by validating flags and `limit`, trimming and filtering `taxonomy_to_search`, normalizing and validating two-letter `states`, and preserving the per-state query logic to avoid API caps.

### Testing
- Ran package-level checks using `R CMD check` and existing unit tests via `devtools::test()` with no errors or warnings reported.  
- Executed smoke tests for modified functions including `generate_random_ids`, `rename_columns_by_substring`, `genderize_fetch`, and `search_by_taxonomy` with empty and typical inputs, and all behaved as expected (no crashes and correct type/validation behavior).  
- Verified that `clean_phase_1_results` and `clean_phase_2_data` workflows produce expected messages and attributes (`original_npi`, `random_id`, and `rename_log`) in sample datasets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8da15f44832c86acd1bc844ce041)