### PR TITLE
Add strict input validation to mystery caller workflow functions

### DIFF
--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -79,6 +79,80 @@ run_mystery_caller_workflow <- function(
   verbose = interactive(),
   npi_progress_observer = NULL
 ) {
+  checkmate::assert_character(
+    taxonomy_terms,
+    null.ok = TRUE,
+    any.missing = FALSE,
+    min.len = 1,
+    .var.name = "taxonomy_terms"
+  )
+  checkmate::assert_data_frame(name_data, null.ok = TRUE, .var.name = "name_data")
+  checkmate::assert_data_frame(phase1_data, min.rows = 1, .var.name = "phase1_data")
+  checkmate::assert_character(
+    lab_assistant_names,
+    any.missing = FALSE,
+    min.len = 2,
+    .var.name = "lab_assistant_names"
+  )
+  checkmate::assert_string(output_directory, min.chars = 1, .var.name = "output_directory")
+  checkmate::assert_true(
+    is.data.frame(phase2_data) || (is.character(phase2_data) && length(phase2_data) == 1),
+    .var.name = "phase2_data"
+  )
+  checkmate::assert_string(phase2_output_directory, min.chars = 1, .var.name = "phase2_output_directory")
+  checkmate::assert_string(quality_check_path, min.chars = 1, .var.name = "quality_check_path")
+  checkmate::assert_string(phase1_output_directory, min.chars = 1, .var.name = "phase1_output_directory")
+  checkmate::assert_character(
+    split_insurance_order,
+    any.missing = FALSE,
+    min.len = 1,
+    unique = TRUE,
+    .var.name = "split_insurance_order"
+  )
+  checkmate::assert_character(
+    phase2_required_strings,
+    any.missing = FALSE,
+    min.len = 1,
+    unique = TRUE,
+    .var.name = "phase2_required_strings"
+  )
+  checkmate::assert_character(
+    phase2_standard_names,
+    any.missing = FALSE,
+    min.len = 1,
+    unique = TRUE,
+    .var.name = "phase2_standard_names"
+  )
+  checkmate::assert_true(
+    length(phase2_required_strings) == length(phase2_standard_names),
+    .var.name = "phase2_required_strings/phase2_standard_names length parity"
+  )
+  checkmate::assert_true(
+    nzchar(trimws(quality_check_path)),
+    .var.name = "quality_check_path non-empty after trim"
+  )
+  checkmate::assert_list(npi_search_args, names = "named", .var.name = "npi_search_args")
+  checkmate::assert_subset(
+    names(npi_search_args),
+    choices = c(
+      "year", "years", "limit", "pause_seconds", "skip_validation",
+      "batch_size", "progress_callback", "heartbeat_seconds",
+      "config_file", "config_path", "max_retries"
+    ),
+    empty.ok = TRUE,
+    .var.name = "npi_search_args names"
+  )
+  if (!is.null(npi_search_args$progress_callback)) {
+    checkmate::assert_function(npi_search_args$progress_callback, .var.name = "npi_search_args$progress_callback")
+  }
+  if (!is.null(npi_search_args$skip_validation)) {
+    checkmate::assert_flag(npi_search_args$skip_validation, .var.name = "npi_search_args$skip_validation")
+  }
+  checkmate::assert_character(all_states, null.ok = TRUE, any.missing = FALSE, .var.name = "all_states")
+  checkmate::assert_character(all_states, null.ok = TRUE, unique = TRUE, .var.name = "all_states unique")
+  checkmate::assert_flag(verbose, .var.name = "verbose")
+  checkmate::assert_function(npi_progress_observer, null.ok = TRUE, .var.name = "npi_progress_observer")
+
   announce <- function(stage) {
     if (isTRUE(verbose)) {
       message(sprintf("[%s] %s", format(Sys.time(), "%H:%M:%S"), stage))
@@ -143,13 +217,8 @@ run_mystery_caller_workflow <- function(
 
   roster_names <- tibble::tibble()
   if (!is.null(name_data)) {
-    if (!is.data.frame(name_data)) {
-      stop("`name_data` must be a data frame with `first` and `last` columns.")
-    }
+    checkmate::assert_names(names(name_data), must.include = c("first", "last"), .var.name = "name_data columns")
     if (nrow(name_data)) {
-      if (!all(c("first", "last") %in% names(name_data))) {
-        stop("`name_data` must contain columns named `first` and `last`.")
-      }
       announce("Searching NPIs by name")
       args <- utils::modifyList(list(data = name_data), npi_search_args)
       user_callback <- NULL

--- a/R/run_mystery_caller_workflow_with_logging.R
+++ b/R/run_mystery_caller_workflow_with_logging.R
@@ -58,9 +58,22 @@ run_mystery_caller_workflow_with_logging <- function(input_data,
                                                       log_file = NULL,
                                                       skip_preflight = FALSE) {
 
+  checkmate::assert(
+    checkmate::check_string(input_data, min.chars = 1),
+    checkmate::check_data_frame(input_data, min.rows = 1),
+    .var.name = "input_data"
+  )
   checkmate::assert_string(output_dir, min.chars = 1, any.missing = FALSE)
-  checkmate::assert_flag(skip_preflight)
+  checkmate::assert_string(google_maps_api_key, min.chars = 1, any.missing = FALSE)
+  checkmate::assert_string(here_api_key, min.chars = 1, any.missing = FALSE)
   checkmate::assert_numeric(drive_time_minutes, any.missing = FALSE, min.len = 1)
+  checkmate::assert_true(all(drive_time_minutes >= 1), .var.name = "drive_time_minutes minimum 1 minute")
+  checkmate::assert_true(all(drive_time_minutes <= 1440), .var.name = "drive_time_minutes maximum 1440 minutes")
+  checkmate::assert_int(census_year, lower = 2000, upper = as.integer(format(Sys.Date(), "%Y")), .var.name = "census_year")
+  checkmate::assert_string(log_file, null.ok = TRUE, min.chars = 1, .var.name = "log_file")
+  checkmate::assert_flag(skip_preflight)
+
+  checkmate::assert_string(output_dir, min.chars = 1, any.missing = FALSE)
   checkmate::assert_true(all(is.finite(drive_time_minutes)), .var.name = "drive_time_minutes finite")
   checkmate::assert_true(all(drive_time_minutes > 0), .var.name = "drive_time_minutes positive")
   drive_time_minutes <- sort(unique(as.integer(round(drive_time_minutes))))


### PR DESCRIPTION
### Motivation

- Harden the mystery caller workflow against bad inputs by validating argument types, lengths, and contents before execution.
- Make failures fail-fast with clearer error messages and ensure downstream logic receives well-formed data. 
- Improve observability of NPI search arguments and API credential parameters for the logging wrapper.

### Description

- Added comprehensive `checkmate` assertions to `run_mystery_caller_workflow` to validate `taxonomy_terms`, `name_data`, `phase1_data`, `lab_assistant_names`, output/phase directories, `phase2_data`, `split_insurance_order`, `phase2_required_strings`, `phase2_standard_names`, parity of phase2 name vectors, `quality_check_path` (trimmed non-empty), `npi_search_args` (named list and allowed keys), optional `progress_callback` and `skip_validation` types, `all_states`, `verbose`, and `npi_progress_observer`.
- Replaced manual `name_data` checks with `checkmate::assert_names` to require `first` and `last` columns and preserve the name-based NPI search flow and progress callback composition.
- Added input validation to `run_mystery_caller_workflow_with_logging` to accept either a non-empty string or a data frame for `input_data`, require non-empty API keys (`google_maps_api_key`, `here_api_key`), constrain `drive_time_minutes` bounds and finiteness, enforce `census_year` range, validate `log_file` and `skip_preflight`, and re-assert `output_dir`.

### Testing

- Ran the package automated test suite (unit tests) and `R CMD check` against the modified code; the test suite completed successfully. 
- Verified existing workflows that exercise name- and taxonomy-based NPI searches still progress through the same callback composition logic under the new assertions. 
- Linted the modified files for style and no additional warnings were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9554d06c832c82609638b350727e)