### PR TITLE
Add comprehensive checkmate validations to workflow entrypoint

### DIFF
--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -80,6 +80,33 @@ run_mystery_caller_workflow <- function(
   verbose = interactive(),
   npi_progress_observer = NULL
 ) {
+  checkmate::assert_character(taxonomy_terms, null.ok = TRUE, any.missing = FALSE, .var.name = "taxonomy_terms")
+  if (!is.null(taxonomy_terms)) {
+    checkmate::assert_character(taxonomy_terms, min.len = 1, .var.name = "taxonomy_terms")
+  }
+  checkmate::assert_data_frame(name_data, null.ok = TRUE, .var.name = "name_data")
+  checkmate::assert_data_frame(phase1_data, .var.name = "phase1_data")
+  checkmate::assert_character(lab_assistant_names, min.len = 2, any.missing = FALSE, .var.name = "lab_assistant_names")
+  checkmate::assert_string(output_directory, min.chars = 1, .var.name = "output_directory")
+  checkmate::assert(
+    checkmate::check_string(phase2_data, min.chars = 1),
+    checkmate::check_data_frame(phase2_data)
+  )
+  checkmate::assert_string(phase2_output_directory, min.chars = 1, .var.name = "phase2_output_directory")
+  checkmate::assert_string(quality_check_path, min.chars = 1, .var.name = "quality_check_path")
+  checkmate::assert_string(phase1_output_directory, min.chars = 1, .var.name = "phase1_output_directory")
+  checkmate::assert_character(split_insurance_order, min.len = 1, any.missing = FALSE, .var.name = "split_insurance_order")
+  checkmate::assert_character(phase2_required_strings, min.len = 1, any.missing = FALSE, .var.name = "phase2_required_strings")
+  checkmate::assert_character(phase2_standard_names, min.len = 1, any.missing = FALSE, .var.name = "phase2_standard_names")
+  checkmate::assert_list(npi_search_args, names = "named", .var.name = "npi_search_args")
+  checkmate::assert_character(all_states, null.ok = TRUE, any.missing = FALSE, .var.name = "all_states")
+  checkmate::assert_flag(verbose, .var.name = "verbose")
+  checkmate::assert_function(npi_progress_observer, null.ok = TRUE, .var.name = "npi_progress_observer")
+
+  if (length(phase2_required_strings) != length(phase2_standard_names)) {
+    stop("`phase2_required_strings` and `phase2_standard_names` must have the same length.", call. = FALSE)
+  }
+
   announce <- function(stage) {
     if (isTRUE(verbose)) {
       message(sprintf("[%s] %s", format(Sys.time(), "%H:%M:%S"), stage))


### PR DESCRIPTION
### Motivation
- Harden the public entrypoint `run_mystery_caller_workflow()` by making argument expectations explicit and failing early for invalid inputs. 
- Prevent common downstream failures caused by malformed inputs (data frames, strings/paths, vectors, callbacks, and named lists). 
- Ensure Phase 2 column mapping configuration is consistent by validating pairwise lengths of required and standard name vectors.

### Description
- Inserted a block of `checkmate` assertions at the top of `run_mystery_caller_workflow()` validating `taxonomy_terms`, `name_data`, `phase1_data`, `lab_assistant_names`, and `output_directory` types and shapes. 
- Added validation that `phase2_data` is either a non-empty string or a data frame using `checkmate::assert()` with `check_string` and `check_data_frame`. 
- Added `checkmate` assertions for `phase2_output_directory`, `quality_check_path`, `phase1_output_directory`, `split_insurance_order`, `phase2_required_strings`, `phase2_standard_names`, `npi_search_args` (named list), `all_states`, `verbose`, and `npi_progress_observer`. 
- Added an explicit guard that stops with a clear message when `length(phase2_required_strings) != length(phase2_standard_names)` to avoid alignment bugs in Phase 2 processing.

### Testing
- Attempted to parse the modified file with `Rscript -e "parse(file='R/run_mystery_caller_workflow.R')"` but `Rscript` is not available in this environment so runtime parsing could not be executed. 
- No automated R unit tests or linters were executed in this environment due to the missing R runtime. 
- Static changes were limited to a single function file and are small and localized, so no additional automated checks were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03919c5224832c92d18aebf7189f7b)