### PR TITLE
Add checkmate validations in overlap and intersection helpers

### DIFF
--- a/R/calculate_intersection_overlap_and_save.R
+++ b/R/calculate_intersection_overlap_and_save.R
@@ -48,22 +48,15 @@ calculate_intersection_overlap_and_save <- function(block_groups,
   }
 
   # Parameter validation
-  if (!inherits(block_groups, "sf")) {
-    stop("Error: 'block_groups' must be an sf object.", call. = FALSE)
-  }
-  if (!inherits(isochrones_joined, "sf")) {
-    stop("Error: 'isochrones_joined' must be an sf object.", call. = FALSE)
-  }
-  if (!is.numeric(drive_time_minutes) || length(drive_time_minutes) != 1L || drive_time_minutes < 0) {
-    stop("Error: 'drive_time_minutes' must be a single non-negative numeric value.", call. = FALSE)
-  }
-  if (!is.character(output_dir) || !nzchar(output_dir)) {
-    stop("Error: 'output_dir' must be a non-empty character string.", call. = FALSE)
-  }
-  if (!is.null(crosswalk) && !is.function(crosswalk)) {
-    stop("Error: 'crosswalk' must be a function or NULL.", call. = FALSE)
-  }
+  checkmate::assert_class(block_groups, classes = "sf", .var.name = "block_groups")
+  checkmate::assert_class(isochrones_joined, classes = "sf", .var.name = "isochrones_joined")
+  checkmate::assert_number(drive_time_minutes, lower = 0, finite = TRUE, .var.name = "drive_time_minutes")
+  checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_function(crosswalk, null.ok = TRUE, .var.name = "crosswalk")
   checkmate::assert_flag(notify, .var.name = "notify")
+  checkmate::assert_true(nrow(block_groups) > 0, .var.name = "block_groups")
+  checkmate::assert_true(nrow(isochrones_joined) > 0, .var.name = "isochrones_joined")
+  checkmate::assert_true(all(!is.na(isochrones_joined$drive_time)), .var.name = "isochrones_joined$drive_time")
 
   validated <- validate_sf_inputs(
     block_groups = block_groups,
@@ -88,6 +81,8 @@ calculate_intersection_overlap_and_save <- function(block_groups,
     stop("`block_groups` must include a `vintage` column indicating ACS vintage.", call. = FALSE)
   }
 
+  checkmate::assert_numeric(isochrones_joined$data_year, any.missing = FALSE, finite = TRUE, .var.name = "isochrones_joined$data_year")
+  checkmate::assert_numeric(block_groups$vintage, any.missing = FALSE, finite = TRUE, .var.name = "block_groups$vintage")
   provider_years <- stats::na.omit(unique(isochrones_joined$data_year))
   acs_years <- stats::na.omit(unique(block_groups$vintage))
 

--- a/R/map_create_block_group_overlap.R
+++ b/R/map_create_block_group_overlap.R
@@ -35,6 +35,8 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
     stop("Package 'htmlwidgets' is required for this function. Install with: install.packages('htmlwidgets')", call. = FALSE)
   }
   checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_true(nrow(bg_data) > 0, .var.name = "bg_data")
+  checkmate::assert_true(nrow(isochrones_data) > 0, .var.name = "isochrones_data")
   if (!inherits(bg_data, "sf")) {
     stop("`bg_data` must be an sf object with polygon geometries.", call. = FALSE)
   }
@@ -47,6 +49,7 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
   if (!is.numeric(isochrones_data$drive_time)) {
     stop("`isochrones_data$drive_time` must be a numeric column.", call. = FALSE)
   }
+  checkmate::assert_numeric(isochrones_data$drive_time, any.missing = FALSE, finite = TRUE, .var.name = "isochrones_data$drive_time")
   if (!"overlap" %in% names(bg_data)) {
     stop("`bg_data` must include an `overlap` column (proportion 0-1). Run calculate_intersection_overlap_and_save() first.", call. = FALSE)
   }


### PR DESCRIPTION
### Motivation
- Harden input validation for geospatial overlap workflows by replacing scattered ad-hoc checks with consistent `checkmate` assertions to surface clearer failures earlier. 
- Ensure required fields (`drive_time`, `data_year`, `vintage`, `GEOID`, and `overlap`) are present and well-typed prior to heavy spatial processing to reduce obscure runtime errors.

### Description
- Replaced manual type/value checks in `calculate_intersection_overlap_and_save()` with `checkmate` assertions: `assert_class` for `sf` inputs, `assert_number` for `drive_time_minutes`, `assert_string` for `output_dir`, `assert_function` for `crosswalk`, and `assert_flag` for `notify`.
- Added presence and non-empty checks in `calculate_intersection_overlap_and_save()` using `checkmate::assert_true` to ensure `nrow(block_groups) > 0`, `nrow(isochrones_joined) > 0`, and non-missing `isochrones_joined$drive_time`, plus `assert_numeric` checks for `isochrones_joined$data_year` and `block_groups$vintage` before year alignment logic.
- Added complementary validations in `map_create_block_group_overlap()` to assert non-empty `bg_data`/`isochrones_data` and finite numeric `isochrones_data$drive_time` using `checkmate::assert_true` and `checkmate::assert_numeric`.
- Kept existing `validate_sf_inputs()` and targeted runtime `stop()` guards for semantic conditions (e.g., `overlap` bounds, required columns) while surfacing earlier, clearer failures via `checkmate`.

### Testing
- Attempted to run the overlap validation unit tests with `Rscript -e "testthat::test_file('tests/testthat/test-overlap-checkmate-validations.R')"` but the environment lacks `Rscript` so the test invocation failed with `/bin/bash: Rscript: command not found` and no tests were executed.
- No other automated tests were executed in this environment due to missing R runtime tools, so CI/test execution should be run in the standard R-enabled CI environment to verify behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0391e9a740832c90bcd0c7f500a4a9)