### PR TITLE
Add 10 checkmate validations to preflight helpers

### DIFF
--- a/R/preflight_checks.R
+++ b/R/preflight_checks.R
@@ -52,10 +52,19 @@ tyler_preflight_check <- function(input_data,
                                    interactive = interactive(),
                                    required_columns = c("first", "last")) {
 
+  checkmate::assert(
+    checkmate::check_data_frame(input_data),
+    checkmate::check_string(input_data, min.chars = 1),
+    .var.name = "input_data"
+  )
+  checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_string(google_maps_api_key, null.ok = TRUE, .var.name = "google_maps_api_key")
+  checkmate::assert_string(here_api_key, null.ok = TRUE, .var.name = "here_api_key")
   checkmate::assert_flag(check_apis)
   checkmate::assert_flag(estimate_resources)
   checkmate::assert_flag(interactive)
-  checkmate::assert_character(required_columns, any.missing = FALSE)
+  checkmate::assert_character(required_columns, min.len = 1, any.missing = FALSE, unique = TRUE, .var.name = "required_columns")
+  checkmate::assert_true(all(nzchar(trimws(required_columns))), .var.name = "required_columns")
 
   message("")
   message("\u256D", strrep("\u2500", 58), "\u256E")
@@ -365,6 +374,7 @@ tyler_preflight_check <- function(input_data,
 #' @return List with valid (logical) and error (character) fields
 #' @keywords internal
 tyler_validate_google_api <- function(api_key) {
+  checkmate::assert_string(api_key, min.chars = 1, .var.name = "api_key")
   if (!requireNamespace("ggmap", quietly = TRUE)) {
     return(list(valid = FALSE, error = "Package 'ggmap' is required to validate the Google Maps API key. Install with: install.packages('ggmap')"))
   }
@@ -390,6 +400,7 @@ tyler_validate_google_api <- function(api_key) {
 #' @return List with valid (logical) and error (character) fields
 #' @keywords internal
 tyler_validate_here_api <- function(api_key) {
+  checkmate::assert_string(api_key, min.chars = 1, .var.name = "api_key")
   tryCatch({
     # Try a simple isochrone request
     url <- sprintf(
@@ -423,6 +434,8 @@ tyler_validate_here_api <- function(api_key) {
 #' @family utilities
 #' @export
 tyler_assess_data_quality <- function(data, required_columns = c("first", "last")) {
+  checkmate::assert_data_frame(data, .var.name = "data")
+  checkmate::assert_character(required_columns, min.len = 1, any.missing = FALSE, unique = TRUE, .var.name = "required_columns")
   issues <- list()
   penalties <- 0
   max_penalties <- 10
@@ -496,6 +509,7 @@ tyler_assess_data_quality <- function(data, required_columns = c("first", "last"
 #' @family utilities
 #' @export
 tyler_estimate_resources <- function(n_rows) {
+  checkmate::assert_count(n_rows, positive = FALSE, .var.name = "n_rows")
   # Rough estimates based on typical performance
   # These should be calibrated with real-world data
 


### PR DESCRIPTION
### Motivation
- Harden preflight and supporting helpers so invalid inputs fail fast with clear errors before expensive workflow or network operations run.
- Improve parameter hygiene for API keys, data frames, required column lists, and resource estimators to reduce downstream runtime surprises.

### Description
- Added input validation at the top of `tyler_preflight_check()` to accept either a data frame or a non-empty file path via a `checkmate::assert()` that covers both cases and to validate `output_dir`, optional API key types, and `required_columns` including non-blank names.
- Added explicit `checkmate::assert_string()` checks in `tyler_validate_google_api()` and `tyler_validate_here_api()` to ensure `api_key` is a non-empty string before making API calls.
- Added `checkmate::assert_data_frame()` and `checkmate::assert_character()` checks to `tyler_assess_data_quality()` to validate `data` and `required_columns` up front.
- Added `checkmate::assert_count()` to `tyler_estimate_resources()` to validate `n_rows` is a non-negative count.
- Total of 10 new `checkmate` validations were added across the file and no functional behavior was changed for valid inputs.

### Testing
- Attempted a syntax parse with `Rscript -e "parse(file='R/preflight_checks.R')"`, but the command failed in this environment because `Rscript` is not installed so the parse/runtime test could not be executed.
- No other automated tests were run in this environment; recommend running `R CMD check` and the package test suite in CI to validate no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c1b4c494832c9d95535371e14948)