### PR TITLE
Add checkmate validations to logged workflow entry point

### DIFF
--- a/R/run_mystery_caller_workflow_with_logging.R
+++ b/R/run_mystery_caller_workflow_with_logging.R
@@ -56,6 +56,20 @@ run_mystery_caller_workflow_with_logging <- function(
   log_file = NULL,
   skip_preflight = FALSE
 ) {
+  checkmate::assert_character(taxonomy_terms, null.ok = TRUE, any.missing = FALSE, .var.name = "taxonomy_terms")
+  checkmate::assert_data_frame(name_data, null.ok = TRUE, .var.name = "name_data")
+  checkmate::assert_data_frame(phase1_data, .var.name = "phase1_data")
+  checkmate::assert_character(lab_assistant_names, min.len = 2, any.missing = FALSE, .var.name = "lab_assistant_names")
+  checkmate::assert_string(output_directory, min.chars = 1, .var.name = "output_directory")
+  checkmate::assert(
+    checkmate::check_string(phase2_data, min.chars = 1),
+    checkmate::check_data_frame(phase2_data)
+  )
+  checkmate::assert_string(phase2_output_directory, min.chars = 1, .var.name = "phase2_output_directory")
+  checkmate::assert_string(quality_check_path, min.chars = 1, .var.name = "quality_check_path")
+  checkmate::assert_string(phase1_output_directory, min.chars = 1, .var.name = "phase1_output_directory")
+  checkmate::assert_flag(skip_preflight, .var.name = "skip_preflight")
+
   dir.create(output_directory, showWarnings = FALSE, recursive = TRUE)
 
   if (is.null(log_file)) {


### PR DESCRIPTION
### Motivation

- Ensure the logging wrapper fails fast with clear errors by validating inputs before starting long-running workflows, and align its defensive checks with the main workflow function.

### Description

- Added `checkmate` assertions at the top of `run_mystery_caller_workflow_with_logging()` to validate `taxonomy_terms`, `name_data`, `phase1_data`, `lab_assistant_names`, `output_directory`, `phase2_data` (path or data frame), `phase2_output_directory`, `quality_check_path`, `phase1_output_directory`, and the `skip_preflight` flag.
- The new checks are defensive and preserve existing behavior thereafter (directory creation, `log_file` defaulting, `tyler_workflow_start()`, and delegation to `run_mystery_caller_workflow()`).
- Change is located in `R/run_mystery_caller_workflow_with_logging.R` and adds input validation to the wrapper entry point.

### Testing

- Attempted an automated R parse check with `Rscript -e "parse(file='R/run_mystery_caller_workflow_with_logging.R')"`, which failed because `Rscript` is not available in this environment. 
- No additional automated tests were run in this environment; the change is limited and should be covered by package checks in CI where `Rscript` is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c1bf01fc832c8b32214fce67dd06)