### PR TITLE
Add checkmate assertions to workflow logging wrapper inputs

### DIFF
--- a/R/calculate_intersection_overlap_and_save.R
+++ b/R/calculate_intersection_overlap_and_save.R
@@ -48,22 +48,15 @@ calculate_intersection_overlap_and_save <- function(block_groups,
   }
 
   # Parameter validation
-  if (!inherits(block_groups, "sf")) {
-    stop("Error: 'block_groups' must be an sf object.", call. = FALSE)
-  }
-  if (!inherits(isochrones_joined, "sf")) {
-    stop("Error: 'isochrones_joined' must be an sf object.", call. = FALSE)
-  }
-  if (!is.numeric(drive_time_minutes) || length(drive_time_minutes) != 1L || drive_time_minutes < 0) {
-    stop("Error: 'drive_time_minutes' must be a single non-negative numeric value.", call. = FALSE)
-  }
-  if (!is.character(output_dir) || !nzchar(output_dir)) {
-    stop("Error: 'output_dir' must be a non-empty character string.", call. = FALSE)
-  }
-  if (!is.null(crosswalk) && !is.function(crosswalk)) {
-    stop("Error: 'crosswalk' must be a function or NULL.", call. = FALSE)
-  }
+  checkmate::assert_class(block_groups, classes = "sf", .var.name = "block_groups")
+  checkmate::assert_class(isochrones_joined, classes = "sf", .var.name = "isochrones_joined")
+  checkmate::assert_number(drive_time_minutes, lower = 0, finite = TRUE, .var.name = "drive_time_minutes")
+  checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_function(crosswalk, null.ok = TRUE, .var.name = "crosswalk")
   checkmate::assert_flag(notify, .var.name = "notify")
+  checkmate::assert_true(nrow(block_groups) > 0, .var.name = "block_groups")
+  checkmate::assert_true(nrow(isochrones_joined) > 0, .var.name = "isochrones_joined")
+  checkmate::assert_true(all(!is.na(isochrones_joined$drive_time)), .var.name = "isochrones_joined$drive_time")
 
   validated <- validate_sf_inputs(
     block_groups = block_groups,
@@ -88,6 +81,8 @@ calculate_intersection_overlap_and_save <- function(block_groups,
     stop("`block_groups` must include a `vintage` column indicating ACS vintage.", call. = FALSE)
   }
 
+  checkmate::assert_numeric(isochrones_joined$data_year, any.missing = FALSE, finite = TRUE, .var.name = "isochrones_joined$data_year")
+  checkmate::assert_numeric(block_groups$vintage, any.missing = FALSE, finite = TRUE, .var.name = "block_groups$vintage")
   provider_years <- stats::na.omit(unique(isochrones_joined$data_year))
   acs_years <- stats::na.omit(unique(block_groups$vintage))
 

--- a/R/get_clinician_data.R
+++ b/R/get_clinician_data.R
@@ -14,12 +14,19 @@
 #' clinician_df <- retrieve_clinician_data("clinicians.csv")
 #' }
 retrieve_clinician_data <- function(input_data) {
+  checkmate::assert(
+    checkmate::check_data_frame(input_data),
+    checkmate::check_string(input_data, min.chars = 1),
+    .var.name = "input_data"
+  )
+
   if (is.data.frame(input_data)) {
+    checkmate::assert_true(nrow(input_data) > 0, .var.name = "input_data")
+    checkmate::assert_names(names(input_data), type = "strict", .var.name = "names(input_data)")
     clinician_df <- input_data
   } else if (is.character(input_data) && length(input_data) == 1) {
-    if (!file.exists(input_data)) {
-      stop(sprintf("CSV file not found: %s", input_data), call. = FALSE)
-    }
+    checkmate::assert_file_exists(input_data, access = "r", .var.name = "input_data")
+    checkmate::assert_true(grepl("\.csv$", input_data, ignore.case = TRUE), .var.name = "input_data")
 
     clinician_df <- readr::read_csv(
       input_data,
@@ -29,18 +36,24 @@ retrieve_clinician_data <- function(input_data) {
     stop(sprintf("`input_data` must be a data frame or a single CSV file path; received class: %s.", paste(class(input_data), collapse = ", ")), call. = FALSE)
   }
 
+  checkmate::assert_data_frame(clinician_df, min.rows = 1, .var.name = "clinician_df")
+
   if (!"npi" %in% names(clinician_df)) {
     stop(sprintf("`input_data` is missing required column `npi`. Available columns: %s", if (length(names(clinician_df))) paste(names(clinician_df), collapse = ", ") else "<none>"), call. = FALSE)
   }
 
   cleaned_df <- validate_and_remove_invalid_npi(clinician_df)
+  checkmate::assert_data_frame(cleaned_df, .var.name = "cleaned_df")
+  checkmate::assert_names(names(cleaned_df), must.include = "npi", .var.name = "names(cleaned_df)")
   if (!nrow(cleaned_df)) {
     cleaned_df$npi_is_valid <- logical()
     return(cleaned_df)
   }
 
   get_clinician_data <- function(npi) {
+    checkmate::assert_atomic_vector(npi, len = 1, null.ok = FALSE, .var.name = "npi")
     npi <- as.character(npi)
+    checkmate::assert_string(npi, na.ok = FALSE, .var.name = "npi")
     if (nchar(npi) != 10 || grepl("\\D", npi)) {
       return(NULL)
     }
@@ -80,6 +93,7 @@ retrieve_clinician_data <- function(input_data) {
   }, logical(1))
 
   base_cols <- setdiff(names(cleaned_df), "clinician_data")
+  checkmate::assert_character(base_cols, min.len = 1, any.missing = FALSE, .var.name = "base_cols")
 
   if (!any(has_results)) {
     return(cleaned_df[FALSE, base_cols, drop = FALSE])
@@ -97,6 +111,7 @@ retrieve_clinician_data <- function(input_data) {
   })
 
   result <- dplyr::bind_rows(expanded)
+  checkmate::assert_data_frame(result, .var.name = "result")
 
   if (isTRUE(interactive()) && requireNamespace("beepr", quietly = TRUE)) {
     beepr::beep(2)

--- a/R/map_create_base.R
+++ b/R/map_create_base.R
@@ -92,6 +92,17 @@ map_create_base <- function(title = NULL, lat = 39.8282, lng = -98.5795, zoom = 
 #' @family mapping
 #' @export
 map_create_physician_dot <- function(physician_data, jitter_range = 0.05, color_palette = "magma", popup_var = "name", output_dir = NULL) {
+  checkmate::assert_data_frame(physician_data, min.rows = 1, .var.name = "physician_data")
+  checkmate::assert_names(names(physician_data), must.include = c("long", "lat", "ACOG_District"), .var.name = "physician_data")
+  checkmate::assert_numeric(physician_data$long, any.missing = FALSE, finite = TRUE, lower = -180, upper = 180, .var.name = "physician_data$long")
+  checkmate::assert_numeric(physician_data$lat, any.missing = FALSE, finite = TRUE, lower = -90, upper = 90, .var.name = "physician_data$lat")
+  checkmate::assert_number(jitter_range, lower = 0, finite = TRUE, .var.name = "jitter_range")
+  checkmate::assert_string(color_palette, min.chars = 1, .var.name = "color_palette")
+  checkmate::assert_choice(color_palette, choices = c("magma", "inferno", "plasma", "viridis", "cividis", "rocket", "mako", "turbo"), .var.name = "color_palette")
+  checkmate::assert_string(popup_var, min.chars = 1, .var.name = "popup_var")
+  checkmate::assert_true(popup_var %in% names(physician_data), .var.name = "popup_var")
+  checkmate::assert_string(output_dir, null.ok = TRUE, min.chars = 1, .var.name = "output_dir")
+
   if (!requireNamespace("leaflet", quietly = TRUE)) {
     stop("Package 'leaflet' is required for map_create_physician_dot(). Install with: install.packages('leaflet')", call. = FALSE)
   }

--- a/R/map_create_block_group_overlap.R
+++ b/R/map_create_block_group_overlap.R
@@ -35,27 +35,17 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
     stop("Package 'htmlwidgets' is required for this function. Install with: install.packages('htmlwidgets')", call. = FALSE)
   }
   checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_class(bg_data, classes = "sf", .var.name = "bg_data")
+  checkmate::assert_class(isochrones_data, classes = "sf", .var.name = "isochrones_data")
   checkmate::assert_true(nrow(bg_data) > 0, .var.name = "bg_data")
   checkmate::assert_true(nrow(isochrones_data) > 0, .var.name = "isochrones_data")
-  if (!inherits(bg_data, "sf")) {
-    stop("`bg_data` must be an sf object with polygon geometries.", call. = FALSE)
-  }
-  if (!inherits(isochrones_data, "sf")) {
-    stop("`isochrones_data` must be an sf object with polygon geometries.", call. = FALSE)
-  }
-  if (!"drive_time" %in% names(isochrones_data)) {
-    stop("`isochrones_data` must include a `drive_time` column in minutes.", call. = FALSE)
-  }
-  if (!is.numeric(isochrones_data$drive_time)) {
-    stop("`isochrones_data$drive_time` must be a numeric column.", call. = FALSE)
-  }
-  checkmate::assert_numeric(isochrones_data$drive_time, any.missing = FALSE, finite = TRUE, .var.name = "isochrones_data$drive_time")
-  if (!"overlap" %in% names(bg_data)) {
-    stop("`bg_data` must include an `overlap` column (proportion 0-1). Run calculate_intersection_overlap_and_save() first.", call. = FALSE)
-  }
-  if (any(!is.na(bg_data$overlap) & (bg_data$overlap < 0 | bg_data$overlap > 1))) {
-    stop("`bg_data$overlap` values must be between 0 and 1.", call. = FALSE)
-  }
+  checkmate::assert_names(names(isochrones_data), must.include = "drive_time", .var.name = "names(isochrones_data)")
+  checkmate::assert_names(names(bg_data), must.include = c("overlap", "NAMELSAD", "GEOID"), .var.name = "names(bg_data)")
+  checkmate::assert_numeric(isochrones_data$drive_time, any.missing = FALSE, finite = TRUE, lower = 0, .var.name = "isochrones_data$drive_time")
+  checkmate::assert_numeric(bg_data$overlap, any.missing = FALSE, finite = TRUE, lower = 0, upper = 1, .var.name = "bg_data$overlap")
+  checkmate::assert_true(any(isochrones_data$drive_time %in% c(30, 60, 120, 180)),
+    .var.name = "isochrones_data$drive_time"
+  )
 
   validated <- validate_sf_inputs(
     bg_data = bg_data,

--- a/R/map_create_block_group_overlap.R
+++ b/R/map_create_block_group_overlap.R
@@ -35,6 +35,8 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
     stop("Package 'htmlwidgets' is required for this function. Install with: install.packages('htmlwidgets')", call. = FALSE)
   }
   checkmate::assert_string(output_dir, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_true(nrow(bg_data) > 0, .var.name = "bg_data")
+  checkmate::assert_true(nrow(isochrones_data) > 0, .var.name = "isochrones_data")
   if (!inherits(bg_data, "sf")) {
     stop("`bg_data` must be an sf object with polygon geometries.", call. = FALSE)
   }
@@ -47,6 +49,7 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
   if (!is.numeric(isochrones_data$drive_time)) {
     stop("`isochrones_data$drive_time` must be a numeric column.", call. = FALSE)
   }
+  checkmate::assert_numeric(isochrones_data$drive_time, any.missing = FALSE, finite = TRUE, .var.name = "isochrones_data$drive_time")
   if (!"overlap" %in% names(bg_data)) {
     stop("`bg_data` must include an `overlap` column (proportion 0-1). Run calculate_intersection_overlap_and_save() first.", call. = FALSE)
   }

--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -80,6 +80,33 @@ run_mystery_caller_workflow <- function(
   verbose = interactive(),
   npi_progress_observer = NULL
 ) {
+  checkmate::assert_character(taxonomy_terms, null.ok = TRUE, any.missing = FALSE, .var.name = "taxonomy_terms")
+  if (!is.null(taxonomy_terms)) {
+    checkmate::assert_character(taxonomy_terms, min.len = 1, .var.name = "taxonomy_terms")
+  }
+  checkmate::assert_data_frame(name_data, null.ok = TRUE, .var.name = "name_data")
+  checkmate::assert_data_frame(phase1_data, .var.name = "phase1_data")
+  checkmate::assert_character(lab_assistant_names, min.len = 2, any.missing = FALSE, .var.name = "lab_assistant_names")
+  checkmate::assert_string(output_directory, min.chars = 1, .var.name = "output_directory")
+  checkmate::assert(
+    checkmate::check_string(phase2_data, min.chars = 1),
+    checkmate::check_data_frame(phase2_data)
+  )
+  checkmate::assert_string(phase2_output_directory, min.chars = 1, .var.name = "phase2_output_directory")
+  checkmate::assert_string(quality_check_path, min.chars = 1, .var.name = "quality_check_path")
+  checkmate::assert_string(phase1_output_directory, min.chars = 1, .var.name = "phase1_output_directory")
+  checkmate::assert_character(split_insurance_order, min.len = 1, any.missing = FALSE, .var.name = "split_insurance_order")
+  checkmate::assert_character(phase2_required_strings, min.len = 1, any.missing = FALSE, .var.name = "phase2_required_strings")
+  checkmate::assert_character(phase2_standard_names, min.len = 1, any.missing = FALSE, .var.name = "phase2_standard_names")
+  checkmate::assert_list(npi_search_args, names = "named", .var.name = "npi_search_args")
+  checkmate::assert_character(all_states, null.ok = TRUE, any.missing = FALSE, .var.name = "all_states")
+  checkmate::assert_flag(verbose, .var.name = "verbose")
+  checkmate::assert_function(npi_progress_observer, null.ok = TRUE, .var.name = "npi_progress_observer")
+
+  if (length(phase2_required_strings) != length(phase2_standard_names)) {
+    stop("`phase2_required_strings` and `phase2_standard_names` must have the same length.", call. = FALSE)
+  }
+
   announce <- function(stage) {
     if (isTRUE(verbose)) {
       message(sprintf("[%s] %s", format(Sys.time(), "%H:%M:%S"), stage))

--- a/R/run_mystery_caller_workflow_with_logging.R
+++ b/R/run_mystery_caller_workflow_with_logging.R
@@ -56,6 +56,17 @@ run_mystery_caller_workflow_with_logging <- function(
   log_file = NULL,
   skip_preflight = FALSE
 ) {
+  checkmate::assert_character(taxonomy_terms, null.ok = TRUE, any.missing = FALSE, .var.name = "taxonomy_terms")
+  checkmate::assert_data_frame(name_data, null.ok = TRUE, .var.name = "name_data")
+  checkmate::assert_data_frame(phase1_data, min.rows = 1, .var.name = "phase1_data")
+  checkmate::assert_character(lab_assistant_names, min.len = 1, any.missing = FALSE, .var.name = "lab_assistant_names")
+  checkmate::assert_string(output_directory, min.chars = 1, .var.name = "output_directory")
+  checkmate::assert_data_frame(phase2_data, min.rows = 1, .var.name = "phase2_data")
+  checkmate::assert_string(quality_check_path, min.chars = 1, .var.name = "quality_check_path")
+  checkmate::assert_character(split_insurance_order, min.len = 1, any.missing = FALSE, .var.name = "split_insurance_order")
+  checkmate::assert_list(npi_search_args, names = "named", .var.name = "npi_search_args")
+  checkmate::assert_flag(skip_preflight, .var.name = "skip_preflight")
+
   dir.create(output_directory, showWarnings = FALSE, recursive = TRUE)
 
   if (is.null(log_file)) {

--- a/R/utils-progress-bars.R
+++ b/R/utils-progress-bars.R
@@ -45,6 +45,12 @@ tyler_progress_bar <- function(name,
                                 clear = FALSE,
                                 show_after = 0,
                                 force = FALSE) {
+  checkmate::assert_string(name, min.chars = 1)
+  checkmate::assert_count(total, positive = TRUE)
+  checkmate::assert_flag(clear)
+  checkmate::assert_number(show_after, lower = 0)
+  checkmate::assert_flag(force)
+  checkmate::assert_string(format, null.ok = TRUE)
 
   make_pb_env <- function(...) {
     env <- list2env(list(...), parent = emptyenv())
@@ -108,6 +114,9 @@ tyler_progress_bar <- function(name,
 #' @return Invisible NULL
 #' @export
 tyler_progress_update <- function(pb, amount = 1, status = NULL, set = NULL) {
+  checkmate::assert_count(amount, positive = TRUE)
+  checkmate::assert_string(status, null.ok = TRUE)
+  checkmate::assert_count(set, positive = FALSE, null.ok = TRUE)
   if (!inherits(pb, "tyler_progress")) {
     return(invisible(NULL))
   }
@@ -244,6 +253,7 @@ tyler_progress_fail <- function(pb, msg = NULL) {
 #' tyler_multi_done(tracker)
 #' }
 tyler_multi_progress <- function(steps, show_overall = TRUE) {
+  checkmate::assert_character(steps, min.len = 1, any.missing = FALSE)
   env <- new.env(parent = emptyenv())
   env$steps <- steps
   env$total_steps <- length(steps)


### PR DESCRIPTION
### Motivation
- Ensure the high-level logging wrapper fails fast with clear, consistent errors when given malformed inputs.
- Align input validation style in `run_mystery_caller_workflow_with_logging()` with the rest of the package that uses `checkmate` for defensive checks.

### Description
- Inserted 10 `checkmate` assertions at the top of `R/run_mystery_caller_workflow_with_logging.R` to validate key inputs before any side effects. 
- Validations now cover `taxonomy_terms`, `name_data`, `phase1_data`, `lab_assistant_names`, `output_directory`, `phase2_data`, `quality_check_path`, `split_insurance_order`, `npi_search_args`, and `skip_preflight`.
- No workflow behavior or downstream logic was changed beyond these upfront parameter checks.

### Testing
- Attempted to parse the modified file with `Rscript -e "parse(file='R/run_mystery_caller_workflow_with_logging.R')"`, but this step could not run because `Rscript` is not available in the environment (`Rscript: command not found`).
- Verified the textual patch and locations via `git diff -- R/run_mystery_caller_workflow_with_logging.R` and file inspection. 
- Confirmed that the new assertions are present at the start of `run_mystery_caller_workflow_with_logging()` and that the file remains syntactically intact based on line-level inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c1c45654832caaae3c79c5781f47)