### PR TITLE
Add 10 additional checkmate validations to workflow entrypoint

### DIFF
--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -102,6 +102,16 @@ run_mystery_caller_workflow <- function(
   checkmate::assert_character(all_states, null.ok = TRUE, any.missing = FALSE, .var.name = "all_states")
   checkmate::assert_flag(verbose, .var.name = "verbose")
   checkmate::assert_function(npi_progress_observer, null.ok = TRUE, .var.name = "npi_progress_observer")
+  checkmate::assert_true(nrow(phase1_data) > 0, .var.name = "phase1_data")
+  checkmate::assert_true(!grepl("^\\s*$", output_directory), .var.name = "output_directory")
+  checkmate::assert_true(!grepl("^\\s*$", phase2_output_directory), .var.name = "phase2_output_directory")
+  checkmate::assert_true(!grepl("^\\s*$", phase1_output_directory), .var.name = "phase1_output_directory")
+  checkmate::assert_true(!grepl("^\\s*$", quality_check_path), .var.name = "quality_check_path")
+  checkmate::assert_true(length(unique(lab_assistant_names)) == length(lab_assistant_names), .var.name = "lab_assistant_names")
+  checkmate::assert_true(length(unique(split_insurance_order)) == length(split_insurance_order), .var.name = "split_insurance_order")
+  checkmate::assert_true(length(unique(phase2_required_strings)) == length(phase2_required_strings), .var.name = "phase2_required_strings")
+  checkmate::assert_true(length(unique(phase2_standard_names)) == length(phase2_standard_names), .var.name = "phase2_standard_names")
+  checkmate::assert_names(names(npi_search_args), type = "unique", .var.name = "names(npi_search_args)")
 
   if (length(phase2_required_strings) != length(phase2_standard_names)) {
     stop("`phase2_required_strings` and `phase2_standard_names` must have the same length.", call. = FALSE)


### PR DESCRIPTION
### Motivation
- Improve input hygiene and fail fast in `run_mystery_caller_workflow()` to reduce downstream runtime errors caused by malformed or ambiguous inputs. 
- Address known validation gaps (non-empty rosters, whitespace-only paths, duplicate configuration elements) so callers get immediate, clear errors.

### Description
- Added 10 new `checkmate` assertions at the start of `run_mystery_caller_workflow()` to tighten argument validation and run before any side effects. 
- New checks include `checkmate::assert_true(nrow(phase1_data) > 0)` to ensure a non-empty Phase 1 roster and whitespace guards for path arguments using `grepl`. 
- Added uniqueness checks for `lab_assistant_names`, `split_insurance_order`, `phase2_required_strings`, and `phase2_standard_names` to prevent duplicate entries. 
- Enforced unique names for `npi_search_args` with `checkmate::assert_names(..., type = "unique")` so downstream merging/lookup logic is deterministic.

### Testing
- Attempted to run the workflow unit test with `Rscript -e "testthat::test_file('tests/testthat/test-run_mystery_caller_workflow.R')"` but the environment lacks `Rscript`, so automated R tests could not be executed. 
- The change was applied and committed locally; no automated tests were run successfully in this environment due to the missing R runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c1c97c3c832c84cf65bb8c896ea0)