### PR TITLE
Add checkmate assertions to NPI validation helper

### DIFF
--- a/R/validate_and_remove_invalid_npi.R
+++ b/R/validate_and_remove_invalid_npi.R
@@ -13,9 +13,19 @@
 #' @export
 validate_and_remove_invalid_npi <- function(input_data) {
 
+  checkmate::assert(
+    checkmate::check_data_frame(input_data),
+    checkmate::check_string(input_data, min.chars = 1, len = 1),
+    .var.name = "input_data"
+  )
+
   if (is.data.frame(input_data)) {
     npi_df <- input_data
   } else if (is.character(input_data) && length(input_data) == 1) {
+    checkmate::assert_true(!is.na(input_data), .var.name = "input_data")
+    checkmate::assert_true(nzchar(trimws(input_data)), .var.name = "input_data")
+    checkmate::assert_true(grepl("\\.csv$", input_data, ignore.case = TRUE), .var.name = "input_data")
+
     if (!file.exists(input_data)) {
       stop(sprintf("CSV file not found: %s", input_data), call. = FALSE)
     }
@@ -24,13 +34,19 @@ validate_and_remove_invalid_npi <- function(input_data) {
       input_data,
       col_types = readr::cols(.default = readr::col_guess(), npi = readr::col_character())
     )
+    checkmate::assert_data_frame(npi_df, .var.name = "npi_df")
   } else {
     stop(sprintf("`input_data` must be a data frame or a single CSV file path; received class: %s.", paste(class(input_data), collapse = ", ")), call. = FALSE)
   }
 
+  checkmate::assert_data_frame(npi_df, .var.name = "npi_df")
+  checkmate::assert_names(names(npi_df), type = "unique", .var.name = "names(npi_df)")
+
   if (!"npi" %in% names(npi_df)) {
     stop(sprintf("`input_data` is missing required column `npi`. Available columns: %s", if (length(names(npi_df))) paste(names(npi_df), collapse = ", ") else "<none>"), call. = FALSE)
   }
+
+  checkmate::assert_atomic_vector(npi_df$npi, .var.name = "npi_df$npi")
 
   npi_df <- npi_df %>%
     dplyr::mutate(
@@ -40,7 +56,10 @@ validate_and_remove_invalid_npi <- function(input_data) {
     ) %>%
     dplyr::filter(!is.na(npi) & npi != "")
 
+  checkmate::assert_data_frame(npi_df, .var.name = "npi_df")
+
   total_candidates <- nrow(npi_df)
+  checkmate::assert_count(total_candidates, positive = FALSE, .var.name = "total_candidates")
 
   if (!total_candidates) {
     npi_df$npi_is_valid <- logical()
@@ -48,7 +67,10 @@ validate_and_remove_invalid_npi <- function(input_data) {
     return(npi_df[, unique(c("npi", "npi_is_valid", names(npi_df))), drop = FALSE])
   }
 
+  checkmate::assert_atomic_vector(npi_df$npi, any.missing = FALSE, .var.name = "npi_df$npi")
+
   valid_format <- nchar(npi_df$npi) == 10 & !grepl("\\D", npi_df$npi)
+  checkmate::assert_logical(valid_format, any.missing = FALSE, len = nrow(npi_df), .var.name = "valid_format")
   npi_df$npi_is_valid <- FALSE
 
   if (any(valid_format)) {
@@ -61,6 +83,8 @@ validate_and_remove_invalid_npi <- function(input_data) {
 
   npi_df <- npi_df %>%
     dplyr::filter(!is.na(npi_is_valid) & npi_is_valid)
+
+  checkmate::assert_true(all(npi_df$npi_is_valid), .var.name = "npi_df$npi_is_valid")
 
   message(sprintf(
     "Validated %d candidate NPI(s); %d passed checksum and formatting rules.",


### PR DESCRIPTION
### Motivation
- Harden input validation and fail early in `validate_and_remove_invalid_npi()` to catch malformed inputs closer to the source.
- Align this helper with the repository's existing `checkmate`-heavy validation style and improve error clarity.

### Description
- Added multiple `checkmate` assertions at the top-level input contract to accept either a `data.frame` or a single non-empty string path to a CSV in `R/validate_and_remove_invalid_npi.R`.
- Added CSV path sanity checks (`!NA`, non-blank, `.csv` suffix) and an assertion after the CSV is read to ensure `npi_df` is a valid data frame.
- Added assertions around the `npi` column and vector (`assert_atomic_vector`, post-clean `assert_data_frame`) and a count invariants check for `total_candidates`.
- Added assertions for the computed mask `valid_format` and a final `assert_true(all(npi_df$npi_is_valid))` to ensure returned rows are validated.

### Testing
- Attempted to parse the modified file with `Rscript -e "parse('R/validate_and_remove_invalid_npi.R')"`, which failed because `Rscript` is not available in this environment, so no R-based automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c4f17058832caf96d602e8bba0d7)