### PR TITLE
Add 10 checkmate validations to map_create_block_group_overlap()

### DIFF
--- a/R/map_create_block_group_overlap.R
+++ b/R/map_create_block_group_overlap.R
@@ -46,6 +46,16 @@ map_create_block_group_overlap <- function(bg_data, isochrones_data, output_dir 
   checkmate::assert_true(any(isochrones_data$drive_time %in% c(30, 60, 120, 180)),
     .var.name = "isochrones_data$drive_time"
   )
+  checkmate::assert_true(anyDuplicated(bg_data$GEOID) == 0, .var.name = "bg_data$GEOID")
+  checkmate::assert_true(all(!is.na(sf::st_is_valid(bg_data))), .var.name = "bg_data geometry validity")
+  checkmate::assert_character(bg_data$GEOID, any.missing = FALSE, min.chars = 1, .var.name = "bg_data$GEOID")
+  checkmate::assert_character(bg_data$NAMELSAD, any.missing = FALSE, min.chars = 1, .var.name = "bg_data$NAMELSAD")
+  checkmate::assert_true(all(grepl("^[0-9]{12}$", bg_data$GEOID)), .var.name = "bg_data$GEOID")
+  checkmate::assert_true(all(isochrones_data$drive_time == as.integer(isochrones_data$drive_time)), .var.name = "isochrones_data$drive_time")
+  checkmate::assert_subset(unique(isochrones_data$drive_time), choices = c(30, 60, 120, 180), .var.name = "isochrones_data$drive_time")
+  checkmate::assert_true(all(bg_data$overlap >= 0 & bg_data$overlap <= 1), .var.name = "bg_data$overlap")
+  checkmate::assert_true(any(bg_data$overlap > 0), .var.name = "bg_data$overlap")
+  checkmate::assert_true(nchar(trimws(output_dir)) > 0, .var.name = "output_dir")
 
   validated <- validate_sf_inputs(
     bg_data = bg_data,


### PR DESCRIPTION
### Motivation
- Harden input contracts for the block-group overlap mapping flow to fail early and with clear messages rather than allowing downstream silent failures or incorrect maps by validating GEOID, names, geometries, drive times, overlap values, and output path before processing. 

### Description
- Added 10 `checkmate`-style assertions at the start of `map_create_block_group_overlap()` in `R/map_create_block_group_overlap.R` to tighten input validation. 
- New checks include GEOID uniqueness, GEOID and `NAMELSAD` being non-missing character vectors, GEOID 12-digit format (`^[0-9]{12}$`), geometry validity flags via `sf::st_is_valid()`, integer and allowed-value enforcement for `drive_time`, and numeric bounds/positivity checks for `overlap`. 
- Added a trimmed non-empty check for `output_dir` to prevent empty-path use. 
- No mapping/rendering behavior was changed; validations are scoped to input checking only. 

### Testing
- Attempted to run the targeted test file with `Rscript -e "testthat::test_file('tests/testthat/test-overlap-checkmate-validations.R')"` but could not execute tests because `Rscript` is not available in the environment, so automated tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c4fb26f0832c8674fc35f9511368)