### PR TITLE
Add stricter checkmate validations to tyler_preflight_check

### DIFF
--- a/R/preflight_checks.R
+++ b/R/preflight_checks.R
@@ -65,6 +65,17 @@ tyler_preflight_check <- function(input_data,
   checkmate::assert_flag(interactive)
   checkmate::assert_character(required_columns, min.len = 1, any.missing = FALSE, unique = TRUE, .var.name = "required_columns")
   checkmate::assert_true(all(nzchar(trimws(required_columns))), .var.name = "required_columns")
+  checkmate::assert_true(!grepl("^\\s*$", output_dir), .var.name = "output_dir")
+  checkmate::assert_true(all(!grepl("^\\s*$", required_columns)), .var.name = "required_columns")
+  checkmate::assert_true(all(nchar(required_columns) <= 100), .var.name = "required_columns")
+  checkmate::assert_true(!isTRUE(check_apis) || (!is.null(google_maps_api_key) && !is.null(here_api_key)),
+    .var.name = "check_apis"
+  )
+  checkmate::assert_true(!isTRUE(check_apis) || (nzchar(trimws(google_maps_api_key)) && nzchar(trimws(here_api_key))),
+    .var.name = "check_apis"
+  )
+  checkmate::assert_true(is.data.frame(input_data) || !grepl("^\\s*$", input_data), .var.name = "input_data")
+  checkmate::assert_true(is.data.frame(input_data) || grepl("\\.(csv|parquet)$", input_data, ignore.case = TRUE), .var.name = "input_data")
 
   message("")
   message("\u256D", strrep("\u2500", 58), "\u256E")
@@ -83,6 +94,9 @@ tyler_preflight_check <- function(input_data,
   errors <- character()
   warnings <- character()
   estimates <- NULL
+  checkmate::assert_list(checks, names = "strict", .var.name = "checks")
+  checkmate::assert_character(errors, any.missing = FALSE, .var.name = "errors")
+  checkmate::assert_character(warnings, any.missing = FALSE, .var.name = "warnings")
 
   # ==================== Check 1: Input Data ====================
   message("\U0001F4CA Checking input data...")


### PR DESCRIPTION
### Motivation
- Harden early input validation in the preflight step so malformed or blank inputs (paths, required columns, and API keys) are caught before long-running workflows start.

### Description
- Added multiple `checkmate::assert_*` calls in `R/preflight_checks.R` to enforce non-blank `output_dir`, non-blank and bounded-length (`<= 100`) `required_columns`, presence and non-empty API keys when `check_apis = TRUE`, non-blank `input_data` paths and a file-extension check for `\.csv|\.parquet`, plus structural assertions for the initialized `checks`, `errors`, and `warnings` containers.

### Testing
- Attempted to run `Rscript -e "testthat::test_file('tests/testthat/test-preflight-checks.R')"` but could not execute automated tests in this environment because `Rscript` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c5f82214832c856642b7b7bdf5a4)