### PR TITLE
Add checkmate input validations to create_isochrones_for_dataframe() and tests

### DIFF
--- a/R/create_isochrones_for_dataframe.R
+++ b/R/create_isochrones_for_dataframe.R
@@ -29,13 +29,23 @@ create_isochrones_for_dataframe <- function(
   #input_file <- "_Recent_Grads_GOBA_NPI_2022a.rds" #for testing;
   #input_file <- "data/test_short_inner_join_postmastr_clinician_data_sf.csv"
 
+  checkmate::assert(
+    checkmate::check_data_frame(input_file),
+    checkmate::check_string(input_file, min.chars = 1),
+    .var.name = "input_file"
+  )
+  checkmate::assert_numeric(breaks, min.len = 1, any.missing = FALSE, finite = TRUE, lower = 1, .var.name = "breaks")
+  checkmate::assert_true(length(unique(breaks)) == length(breaks), .var.name = "breaks")
+  checkmate::assert_true(isTRUE(all.equal(breaks, sort(breaks))), .var.name = "breaks")
+  checkmate::assert_string(api_key, min.chars = 1, .var.name = "api_key")
+  checkmate::assert_string(output_dir, null.ok = TRUE, min.chars = 1, .var.name = "output_dir")
+  checkmate::assert_number(save_interval, lower = 0, finite = TRUE, .var.name = "save_interval")
   if (!requireNamespace("hereR", quietly = TRUE)) {
     stop("Package 'hereR' is required for create_isochrones_for_dataframe(). Install with: install.packages('hereR')", call. = FALSE)
   }
   if (!requireNamespace("easyr", quietly = TRUE)) {
     stop("Package 'easyr' is required for create_isochrones_for_dataframe(). Install with: install.packages('easyr')", call. = FALSE)
   }
-  if (is.na(api_key) || !nzchar(api_key)) stop("HERE API key is required via argument or HERE_API_KEY env var.", call. = FALSE)
 
   hereR::set_key(api_key)
   if (is.data.frame(input_file)) {
@@ -46,8 +56,13 @@ create_isochrones_for_dataframe <- function(
 
   # Normalise column names before validation so that "LAT"/"LONG" etc. are accepted
   dataframe <- janitor::clean_names(dataframe)
+  checkmate::assert_data_frame(dataframe, min.rows = 0, .var.name = "dataframe")
+  checkmate::assert_names(names(dataframe), type = "unique", .var.name = "names(dataframe)")
 
   # Check if "lat" and "long" columns exist
+  checkmate::assert_names(names(dataframe), must.include = c("lat", "long"), .var.name = "names(dataframe)")
+  checkmate::assert_numeric(dataframe$lat, any.missing = FALSE, finite = TRUE, .var.name = "dataframe$lat")
+  checkmate::assert_numeric(dataframe$long, any.missing = FALSE, finite = TRUE, .var.name = "dataframe$long")
   if (!all(c("lat", "long") %in% colnames(dataframe))) {
     stop("The dataframe must have 'lat' and 'long' columns.", call. = FALSE)
   }
@@ -102,9 +117,6 @@ create_isochrones_for_dataframe <- function(
     }
   }
 
-  if (!is.numeric(save_interval) || length(save_interval) != 1 || is.na(save_interval) || save_interval <= 0) {
-    stop("save_interval must be a positive number of seconds.", call. = FALSE)
-  }
 
   if (is.null(output_dir)) {
     output_dir <- tyler_tempdir("isochrones", create = TRUE)

--- a/tests/testthat/test-bug-fixes.R
+++ b/tests/testthat/test-bug-fixes.R
@@ -435,3 +435,16 @@ test_that("Edge cases don't break bug fixes", {
   # All tests should complete quickly
   expect_true(TRUE)
 })
+
+test_that("create_isochrones_for_dataframe checkmate input validations trigger", {
+  skip_if_not_installed("hereR")
+  skip_if_not_installed("easyr")
+
+  valid_df <- data.frame(lat = 39.7, long = -104.9)
+
+  expect_error(create_isochrones_for_dataframe(valid_df, breaks = c(3600, 1800), api_key = "dummy"), "breaks")
+  expect_error(create_isochrones_for_dataframe(valid_df, breaks = c(1800, 1800), api_key = "dummy"), "breaks")
+  expect_error(create_isochrones_for_dataframe(valid_df, output_dir = "", api_key = "dummy"), "output_dir")
+  expect_error(create_isochrones_for_dataframe(data.frame(lat = "x", long = -104.9), api_key = "dummy"), "dataframe\\$lat")
+  expect_error(create_isochrones_for_dataframe(data.frame(lat = 39.7), api_key = "dummy"), "names\\(dataframe\\)")
+})


### PR DESCRIPTION
### Motivation
- Ensure invalid inputs are rejected early and consistently by centralizing checks using `checkmate` rather than ad-hoc guards.
- Prevent downstream failures and confusing error states when isochrone generation is run with malformed `breaks`, missing API key, or bad coordinate columns.
- Align this function with the package-wide validation approach used elsewhere (preflight/checkmate patterns). 

### Description
- Added `checkmate` assertions at the top of `create_isochrones_for_dataframe()` to validate `input_file`, `breaks` (numeric, positive, unique, sorted), `api_key`, optional `output_dir`, and `save_interval`.
- After loading and normalizing the input with `janitor::clean_names()` the code now asserts the loaded `dataframe` shape, unique column names, and requires `lat`/`long` to be numeric and finite before continuing.
- Removed redundant manual ad-hoc checks that are now covered by `checkmate` assertions (for example previous `api_key` and `save_interval` manual checks were replaced).
- Added a new test block to `tests/testthat/test-bug-fixes.R` that asserts validation errors are raised for unsorted/duplicate `breaks`, empty `output_dir`, non-numeric `lat`, and missing `long` column, and uses `skip_if_not_installed()` for `hereR`/`easyr`.

### Testing
- Attempted to run the updated tests with `Rscript -e 'testthat::test_file("tests/testthat/test-bug-fixes.R")'` but the runtime container lacks `Rscript` so the test run could not be executed (`/bin/bash: Rscript: command not found`).
- The new tests include `skip_if_not_installed()` guards so they will run in an environment with `hereR` and `easyr` installed and will trigger the new `checkmate` validation paths when executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c5ff1f9c832ca65c1e64a26117e2)