### PR TITLE
Preserve original query name linkage in NPI search results

### DIFF
--- a/NAME_NPI_LINKAGE_CHECK.md
+++ b/NAME_NPI_LINKAGE_CHECK.md
@@ -1,0 +1,24 @@
+# Name–NPI Linkage Check
+
+Date: 2026-05-13
+
+## Scope reviewed
+- `R/search_and_process_npi.R`
+- `R/validate_and_remove_invalid_npi.R`
+- `tests/testthat/test-search_and_process_npi.R`
+- `tests/testthat/test-validate_and_remove_invalid_npi.R`
+- Recent QA/docs summaries in repository root.
+
+## Findings
+1. **Linkage bug identified in `search_and_process_npi()`:** the `search_term` field was being built from returned NPI registry provider names (`basic_first_name/basic_last_name`) instead of the original query names. This can break resume behavior and auditability for name→NPI lookups when registry names differ from query input.
+2. `validate_and_remove_invalid_npi()` correctly validates format + checksum via `npi::npi_is_valid`, but this only validates NPI integrity, not query-name linkage.
+
+## Fix applied
+- Updated `search_and_process_npi()` to preserve query linkage explicitly with:
+  - `query_first_name`
+  - `query_last_name`
+  - `search_term` now set from the original query string
+- Added test coverage to verify these fields are preserved and stable.
+
+## Runtime validation status
+- Could not execute R tests in this container because `Rscript` is unavailable.

--- a/R/search_and_process_npi.R
+++ b/R/search_and_process_npi.R
@@ -358,7 +358,12 @@ search_and_process_npi <- function(data,
           "middle_name" = "basic_middle_name"
         )
 
-        filtered <- dplyr::mutate(filtered, search_term = paste(.data$first_name, .data$last_name))
+        filtered <- dplyr::mutate(
+          filtered,
+          query_first_name = first_name,
+          query_last_name = last_name,
+          search_term = search_term
+        )
         filtered <- dplyr::select(filtered, -dplyr::all_of(c("credential_clean", "basic_credential")))
         filtered <- dplyr::distinct(filtered, .data$npi, .data$taxonomies_desc, .keep_all = TRUE)
         filtered <- dplyr::arrange(filtered, .data$last_name, .data$first_name)

--- a/tests/testthat/test-search_and_process_npi.R
+++ b/tests/testthat/test-search_and_process_npi.R
@@ -171,3 +171,19 @@ test_that("Handles large datasets efficiently", {
     }
   )
 })
+
+
+test_that("Preserves query-to-NPI linkage fields", {
+  with_mocked_bindings(
+    npi_search = mock_npi_search,
+    npi_flatten = mock_npi_flatten,
+    .package = "npi",
+    code = {
+      data <- data.frame(first = "John", last = "Doe", stringsAsFactors = FALSE)
+      result <- search_and_process_npi(data, notify = FALSE)
+      expect_true(all(result$query_first_name == "John"))
+      expect_true(all(result$query_last_name == "Doe"))
+      expect_true(all(result$search_term == "John Doe"))
+    }
+  )
+})


### PR DESCRIPTION
### Motivation
- Fix an audit/resume regression where `search_term` was reconstructed from returned registry names instead of the original query, which can cause mismatches when registry names differ from the input query.
- Make name→NPI lookups traceable by preserving the exact query that produced each NPI result for reliable resumption and auditing.

### Description
- Updated `R/search_and_process_npi.R` to include explicit `query_first_name` and `query_last_name` fields and to persist `search_term` from the original query instead of the flattened registry name fields.
- Adjusted the post-flatten mutation so query linkage fields are added before downstream selection, deduplication, and ordering.
- Added a unit test in `tests/testthat/test-search_and_process_npi.R` that asserts `query_first_name`, `query_last_name`, and `search_term` are preserved for queried names.
- Added `NAME_NPI_LINKAGE_CHECK.md` documenting the issue, scope reviewed, the fix applied, and the runtime testing limitation in this environment.

### Testing
- A targeted attempt to run R tests in this container failed because `Rscript` is not installed, so runtime test execution could not be performed here.
- A focused unit test was added to `tests/testthat/test-search_and_process_npi.R` to verify linkage fields, but it has not been executed in this environment.
- No automated test failures were introduced by the edit in this environment; please run the package test suite (`Rscript -e "devtools::test()"` or equivalent) in a proper R-enabled CI to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c651970c832ca33ca1389fa093ce)