### PR TITLE
Handle partial geocode response row mismatches

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -142,10 +142,15 @@ geocode_unique_addresses <- function(file_path, google_maps_api_key,
 
         if (nrow(coords) != total_unique) {
           warning(sprintf(
-            "Geocoding returned %d rows but expected %d. Some addresses may be missing results.",
+            "Geocoding returned %d rows but expected %d. Missing rows will be padded with NA coordinates.",
             nrow(coords),
             total_unique
           ))
+          if (nrow(coords) < total_unique) {
+            coords[(nrow(coords) + 1):total_unique, c("lat", "lon")] <- NA_real_
+          } else {
+            coords <- coords[seq_len(total_unique), , drop = FALSE]
+          }
         }
 
         break

--- a/tests/testthat/test-geocode.R
+++ b/tests/testthat/test-geocode.R
@@ -79,3 +79,24 @@ test_that("Saves output file correctly", {
     }
   )
 })
+
+
+test_that("Handles partial geocode response without crashing", {
+  temp_csv <- create_temp_csv(sample_data)
+  short_geocode <- function(address, key, ...) {
+    data.frame(lat = c(37.7749, 37.3318), lon = c(-122.4194, -122.0312))
+  }
+
+  with_mocked_bindings(
+    geocode = short_geocode,
+    .package = "ggmap",
+    code = {
+      expect_warning(
+        result <- geocode_unique_addresses(temp_csv, "fake_api_key", notify = FALSE),
+        "Missing rows will be padded with NA coordinates"
+      )
+      expect_equal(nrow(result), nrow(sample_data))
+      expect_true(any(is.na(result$latitude) | is.na(result$longitude)))
+    }
+  )
+})


### PR DESCRIPTION
### Motivation

- Make `geocode_unique_addresses()` resilient when `ggmap::geocode()` returns a different number of rows than the number of unique addresses so downstream `mutate()` operations do not error.  
- Provide a clear, actionable warning when geocoding returns fewer (or more) rows than expected so callers can detect degraded geocoding quality.  
- Add a regression test to prevent this class of failure from regressing in the future.

### Description

- Updated `R/geocode.R` in `geocode_unique_addresses()` to detect when `ggmap::geocode()` returns a row count different from `total_unique` and to normalize the result by padding missing rows with `NA` for `lat`/`lon` or trimming extra rows.  
- Reworded the warning to explain that missing rows will be padded with `NA` coordinates.  
- Added a regression test `test_that("Handles partial geocode response without crashing", ...)` to `tests/testthat/test-geocode.R` which mocks a short/partial `geocode()` response and asserts the function returns the expected number of rows and contains `NA` coordinates for the missing results.  
- Changes committed and staged as part of the PR (`R/geocode.R`, `tests/testthat/test-geocode.R`).

### Testing

- Added the unit test `tests/testthat/test-geocode.R::Handles partial geocode response without crashing` (new test present in the test suite).  
- Attempted to run the geocode test locally with `Rscript -e "testthat::test_file('tests/testthat/test-geocode.R')"`, but automated execution failed because `Rscript`/R is not available in the current environment (no `Rscript` found), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03c63496b4832c98aa45b51b12ee64)