### PR TITLE
Improve workflow summary transparency in mystery caller pipeline

### DIFF
--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -302,6 +302,14 @@ run_mystery_caller_workflow <- function(
       "coverage_summary",
       "quality_check_table"
     ),
+    stage_description = c(
+      "All roster sources merged and deduplicated by NPI",
+      "Roster after NPI validity filtering",
+      "Phase 1 roster after cleaning and exclusions",
+      "Phase 2 data after column normalization and cleaning",
+      "States not yet contacted summary",
+      "Unique NPI/name quality-control export"
+    ),
     n_rows = c(
       nrow(combined_roster),
       nrow(validated_roster),
@@ -310,6 +318,14 @@ run_mystery_caller_workflow <- function(
       if (!is.data.frame(coverage_summary)) NA_integer_ else nrow(coverage_summary),
       if (!is.data.frame(quality_check_table)) NA_integer_ else nrow(quality_check_table)
     ),
+    dropped_rows_from_previous = c(
+      NA_integer_,
+      nrow(combined_roster) - nrow(validated_roster),
+      nrow(validated_roster) - nrow(cleaned_phase1),
+      nrow(cleaned_phase1) - nrow(cleaned_phase2),
+      if (!is.data.frame(coverage_summary)) NA_integer_ else nrow(cleaned_phase2) - nrow(coverage_summary),
+      if (!is.data.frame(quality_check_table)) NA_integer_ else nrow(cleaned_phase2) - nrow(quality_check_table)
+    ),
     retention_from_previous = c(
       NA_real_,
       if (nrow(combined_roster) == 0) NA_real_ else nrow(validated_roster) / nrow(combined_roster),
@@ -317,6 +333,14 @@ run_mystery_caller_workflow <- function(
       if (nrow(cleaned_phase1) == 0) NA_real_ else nrow(cleaned_phase2) / nrow(cleaned_phase1),
       if (!is.data.frame(coverage_summary) || nrow(cleaned_phase2) == 0) NA_real_ else nrow(coverage_summary) / nrow(cleaned_phase2),
       if (!is.data.frame(quality_check_table) || nrow(cleaned_phase2) == 0) NA_real_ else nrow(quality_check_table) / nrow(cleaned_phase2)
+    ),
+    status = c(
+      "created",
+      "created",
+      "created",
+      "created",
+      if (is.data.frame(coverage_summary)) "created" else "skipped_missing_state_column",
+      if (is.data.frame(quality_check_table)) "created" else "skipped_missing_required_columns"
     ),
     output_path = c(
       NA_character_,
@@ -329,7 +353,7 @@ run_mystery_caller_workflow <- function(
   )
 
   if (isTRUE(verbose)) {
-    message("Workflow summary (rows and retention):")
+    message("Workflow summary (rows, retention, and stage status):")
     print(workflow_summary)
     message(sprintf("[%s] Mystery caller workflow complete", format(Sys.time(), "%H:%M:%S")))
   }


### PR DESCRIPTION
### Motivation
- Provide clearer auditability for the end-to-end workflow by making stage intent, row movements, and artifact availability explicit in the summary table.
- Reduce ambiguity during QA and handoffs by surfacing why optional artifacts were skipped and how many rows were dropped between stages.

### Description
- Expanded the `workflow_summary` tibble in `run_mystery_caller_workflow()` to include a `stage_description` column with human-readable stage intent.
- Added `dropped_rows_from_previous` to explicitly report row-loss between sequential stages.
- Added `status` to indicate whether optional artifacts (e.g. `coverage_summary`, `quality_check_table`) were `created` or `skipped_*` with reason labels.
- Updated the verbose console label to `"Workflow summary (rows, retention, and stage status):"` so on-screen output matches the richer table.

### Testing
- Performed static inspection of `R/run_mystery_caller_workflow.R` to confirm the new columns and message text were inserted and the `workflow_summary` is still returned.
- Attempted to source the file with `Rscript -e "source('R/run_mystery_caller_workflow.R')"`, but the command failed because `Rscript` is not available in this environment, so no runtime execution tests were run.
- No additional automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06771ff448832caadec3be47fb35fa)