### PR TITLE
Fix split_and_save RDA input handling

### DIFF
--- a/R/Splitting_dataframe_to_send_to_callers.R
+++ b/R/Splitting_dataframe_to_send_to_callers.R
@@ -46,8 +46,29 @@ split_and_save <- function(data_or_path, output_directory, lab_assistant_names, 
     ext <- tolower(tools::file_ext(data_or_path))
     if (ext %in% c("csv", "parquet")) {
       data <- tyler_read_table(data_or_path)
-    } else if (ext %in% c("rds", "rda")) {
+    } else if (ext == "rds") {
       data <- readRDS(data_or_path)
+    } else if (ext == "rda") {
+      loaded_names <- load(data_or_path)
+      if (!length(loaded_names)) {
+        stop("RDA file did not contain any objects.", call. = FALSE)
+      }
+      if (length(loaded_names) > 1) {
+        stop(
+          "RDA file contains multiple objects. Please provide an .rds file or an .rda with exactly one data frame object.",
+          call. = FALSE
+        )
+      }
+      data <- get(loaded_names[[1]], inherits = FALSE)
+      if (!is.data.frame(data)) {
+        stop(
+          sprintf(
+            "Object '%s' loaded from RDA file is not a data frame.",
+            loaded_names[[1]]
+          ),
+          call. = FALSE
+        )
+      }
     } else if (ext %in% c("xls", "xlsx")) {
       if (!requireNamespace("readxl", quietly = TRUE)) {
         stop("Reading Excel workbooks requires the 'readxl' package. Install it with install.packages('readxl').", call. = FALSE)


### PR DESCRIPTION
### Motivation
- Fix incorrect handling of `.rda` inputs in `split_and_save()` which previously routed `.rda` files through `readRDS()` and could produce confusing failures or non-data.frame results.

### Description
- Add distinct branches for `ext == "rds"` and `ext == "rda"`, load `.rda` with `load()`, and validate the loaded object with clear errors for empty files, multiple objects, or non-data.frame objects.

### Testing
- Attempted to run `testthat::test_file('tests/testthat/test-validate_and_remove_invalid_npi.R')` but execution failed because `R` is not available in this environment, so no package tests could be executed; commit and diff inspection completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0678faf9bc832c8331680a91af3617)