### PR TITLE
Require exact matches in Phase 2 column renaming to prevent ambiguous renames

### DIFF
--- a/R/clean_phase_2_results.R
+++ b/R/clean_phase_2_results.R
@@ -66,15 +66,11 @@ rename_columns_by_substring <- function(data, target_strings, new_names) {
     replacement <- trimws(new_names[i])
     normalized_names <- tolower(names(data))
 
-    # Prefer exact case-insensitive matches first.
+    # Use exact case-insensitive matching only.
+    # Substring matching can silently target the wrong column (e.g. "doctor"
+    # matching both "doctor_name" and "undoctored").
     matches <- normalized_names == target
-    # Fall back to substring matching to preserve historical behavior and
-    # prevent downstream column mismatch errors when callers pass patterns.
     matched_by <- "exact"
-    if (!any(matches)) {
-      matches <- grepl(target, normalized_names, fixed = TRUE)
-      matched_by <- "substring"
-    }
     matched_cols <- names(data)[matches]
 
     # Detailed log of what matches were found


### PR DESCRIPTION
### Motivation
- Substring-based fallback matching in `rename_columns_by_substring()` could silently match unintended columns (e.g. `doctor` matching `undoctored`), causing downstream data integrity issues. 
- Make column renaming deterministic and safer by requiring exact case-insensitive column name matches.

### Description
- Updated `rename_columns_by_substring()` in `R/clean_phase_2_results.R` to use exact case-insensitive matching (`normalized_names == target`) and removed the substring fallback logic. 
- Kept existing ambiguity guardrails so the function still errors when multiple exact matches are found and prevents renaming to an already-existing target name. 
- Change is limited to the matching strategy and logging within the renaming loop (small diff applied to `R/clean_phase_2_results.R`).

### Testing
- Attempted to run the package test suite with `testthat::test_dir("tests/testthat")`, but the run failed because `R` is not available in this execution environment (`/bin/bash: line 1: R: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06790d2938832cbdb7f30599d376cb)