### PR TITLE
feat: label-override args for flow_diagram + strobe_flow (generic pipelines)

### DIFF
--- a/R/flow_diagram.R
+++ b/R/flow_diagram.R
@@ -27,6 +27,13 @@ NULL
 #' @param exclusion_reasons Named character vector. Names `"contact"` and/or
 #'   `"complete"` map to reason strings appended below the exclusion count
 #'   (e.g. `c(contact = "Retired or wrong specialty", complete = "No answer")`).
+#' @param label_identified,label_contacted,label_completed,label_analysed
+#'   Character. Box headers for the four stages (the count is appended
+#'   automatically). Override to repurpose the diagram for a non-mystery-caller
+#'   pipeline (e.g. `label_completed = "Target subspecialists"`). Defaults are
+#'   the mystery-caller wording.
+#' @param label_excluded Character. Header for the right-side exclusion boxes.
+#'   Default `"Excluded"`.
 #' @param title Character. Plot title. Default `"Study Flow Diagram"`.
 #' @param output_path Character or `NULL`. File path to save the plot via
 #'   [ggplot2::ggsave()]. Extension determines format (`.png`, `.pdf`, etc.).
@@ -62,6 +69,11 @@ mysterycall_flow_diagram <- function(n_identified,
                                       n_excluded_complete = NULL,
                                       n_analysed,
                                       exclusion_reasons   = NULL,
+                                      label_identified    = "Physicians identified",
+                                      label_contacted     = "Physicians contacted",
+                                      label_completed     = "Calls completed",
+                                      label_analysed      = "Physicians analysed",
+                                      label_excluded      = "Excluded",
                                       title               = "Study Flow Diagram",
                                       output_path         = NULL,
                                       width               = 8,
@@ -145,7 +157,7 @@ mysterycall_flow_diagram <- function(n_identified,
 
   .add_exclusion <- function(p, y_branch, n_excl, reason) {
     if (is.null(n_excl)) return(p)
-    lbl <- .box_label("Excluded", n_excl, reason)
+    lbl <- .box_label(label_excluded, n_excl, reason)
     p <- p +
       ggplot2::annotate("segment",
                          x = cx, xend = ex - bw,
@@ -162,7 +174,7 @@ mysterycall_flow_diagram <- function(n_identified,
 
   # --- Box 1: identified -------------------------------------------------------
   p <- .add_box(p, ypos["identified"],
-                .box_label("Physicians identified", n_identified))
+                .box_label(label_identified, n_identified))
 
   # exclusion after identification
   excl_y1 <- (ypos["identified"] + ypos["contacted"]) / 2
@@ -176,7 +188,7 @@ mysterycall_flow_diagram <- function(n_identified,
     from_y <- if (!is.null(n_excluded_contact)) excl_y1 - bh else ypos["identified"]
     p <- .add_arrow_down(p, from_y, ypos["contacted"])
     p <- .add_box(p, ypos["contacted"],
-                  .box_label("Physicians contacted", n_contacted))
+                  .box_label(label_contacted, n_contacted))
   }
 
   # exclusion after contact / before complete
@@ -197,7 +209,7 @@ mysterycall_flow_diagram <- function(n_identified,
     }
     p <- .add_arrow_down(p, from_y2, ypos["completed"])
     p <- .add_box(p, ypos["completed"],
-                  .box_label("Calls completed", n_completed))
+                  .box_label(label_completed, n_completed))
   }
 
   # --- Box 4: analysed ---------------------------------------------------------
@@ -212,7 +224,7 @@ mysterycall_flow_diagram <- function(n_identified,
   }
   p <- .add_arrow_down(p, prev_y, ypos["analysed"])
   p <- .add_box(p, ypos["analysed"],
-                .box_label("Physicians analysed", n_analysed))
+                .box_label(label_analysed, n_analysed))
 
   if (!is.null(output_path)) {
     ggplot2::ggsave(output_path, plot = p, width = width, height = height)

--- a/R/strobe_flow.R
+++ b/R/strobe_flow.R
@@ -70,6 +70,14 @@ NULL
 #' @param label_included Character. Box label for the included set.
 #' @param label_logistic Character. Box label for the logistic analysis.
 #' @param label_waittime Character. Box label for the wait-time analysis.
+#' @param label_excl_calldate Character. Header for the first (pre-call-date)
+#'   exclusion box; the count is appended automatically. Override to repurpose
+#'   the diagram for a non-mystery-caller pipeline. Default
+#'   `"No call date recorded"`.
+#' @param label_excl_screen Character. Header for the middle screening-exclusion
+#'   box. Default `"Excluded"`.
+#' @param label_excl_waittime Character. Header for the wait-time exclusion box.
+#'   Default `"No appointment date\n(not offered or pending)"`.
 #' @param title Character. Plot title.
 #' @param output_path Character or `NULL`. File path to save the diagram
 #'   (`.png`, `.tiff`, `.pdf`, `.svg`).  When `NULL` (default), no file is
@@ -125,6 +133,9 @@ mysterycall_strobe_flow <- function(
     label_included   = "Scheduling discussion possible\n(exclusion code = 0)",
     label_logistic   = "Logistic analysis\nOutcome: appointment offered (yes/no)",
     label_waittime   = "Wait-time analysis\nOutcome: days to appointment",
+    label_excl_calldate = "No call date recorded",
+    label_excl_screen   = "Excluded",
+    label_excl_waittime = "No appointment date\n(not offered or pending)",
     title            = "STROBE Flow Diagram - Mystery-Caller Study",
     output_path      = NULL,
     width            = 9,
@@ -225,17 +236,16 @@ mysterycall_strobe_flow <- function(
                           sprintf("  - %s: %d", code_labels[[code]], as.integer(n)))
     }
     excl_screen_lbl <- paste0(
-      "Excluded (n = ", .fmt_n(excl_total_screen), ")\n",
+      label_excl_screen, " (n = ", .fmt_n(excl_total_screen), ")\n",
       paste(detail_lines, collapse = "\n")
     )
   } else {
-    excl_screen_lbl <- sprintf("Excluded\n(n = %s)", .fmt_n(excl_total_screen))
+    excl_screen_lbl <- sprintf("%s\n(n = %s)", label_excl_screen, .fmt_n(excl_total_screen))
   }
 
   excl_waittime <- n_logistic - n_waittime
-  excl_ncd_lbl  <- sprintf("No call date recorded\n(n = %s)", .fmt_n(excl_no_calldate))
-  excl_wt_lbl   <- sprintf("No appointment date\n(not offered or pending)\n(n = %s)",
-                            .fmt_n(excl_waittime))
+  excl_ncd_lbl  <- sprintf("%s\n(n = %s)", label_excl_calldate, .fmt_n(excl_no_calldate))
+  excl_wt_lbl   <- sprintf("%s\n(n = %s)", label_excl_waittime, .fmt_n(excl_waittime))
 
   # ---- Layout -----------------------------------------------------------------
   # Layout - all coordinates in [0,1] (y=1 top, y=0 bottom).

--- a/man/mysterycall_flow_diagram.Rd
+++ b/man/mysterycall_flow_diagram.Rd
@@ -12,6 +12,11 @@ mysterycall_flow_diagram(
   n_excluded_complete = NULL,
   n_analysed,
   exclusion_reasons = NULL,
+  label_identified = "Physicians identified",
+  label_contacted = "Physicians contacted",
+  label_completed = "Calls completed",
+  label_analysed = "Physicians analysed",
+  label_excluded = "Excluded",
   title = "Study Flow Diagram",
   output_path = NULL,
   width = 8,
@@ -42,6 +47,14 @@ Must be > 0 and <= \code{n_identified}.}
 \item{exclusion_reasons}{Named character vector. Names \code{"contact"} and/or
 \code{"complete"} map to reason strings appended below the exclusion count
 (e.g. \code{c(contact = "Retired or wrong specialty", complete = "No answer")}).}
+
+\item{label_identified, label_contacted, label_completed, label_analysed}{Character. Box headers for the four stages (the count is appended
+automatically). Override to repurpose the diagram for a non-mystery-caller
+pipeline (e.g. \code{label_completed = "Target subspecialists"}). Defaults are
+the mystery-caller wording.}
+
+\item{label_excluded}{Character. Header for the right-side exclusion boxes.
+Default \code{"Excluded"}.}
 
 \item{title}{Character. Plot title. Default \code{"Study Flow Diagram"}.}
 

--- a/man/mysterycall_strobe_flow.Rd
+++ b/man/mysterycall_strobe_flow.Rd
@@ -22,6 +22,9 @@ mysterycall_strobe_flow(
   label_included = "Scheduling discussion possible\\n(exclusion code = 0)",
   label_logistic = "Logistic analysis\\nOutcome: appointment offered (yes/no)",
   label_waittime = "Wait-time analysis\\nOutcome: days to appointment",
+  label_excl_calldate = "No call date recorded",
+  label_excl_screen = "Excluded",
+  label_excl_waittime = "No appointment date\\n(not offered or pending)",
   title = "STROBE Flow Diagram - Mystery-Caller Study",
   output_path = NULL,
   width = 9,
@@ -79,6 +82,17 @@ Derived automatically when \code{data} or \code{prepared} is supplied.}
 \item{label_logistic}{Character. Box label for the logistic analysis.}
 
 \item{label_waittime}{Character. Box label for the wait-time analysis.}
+
+\item{label_excl_calldate}{Character. Header for the first (pre-call-date)
+exclusion box; the count is appended automatically. Override to repurpose
+the diagram for a non-mystery-caller pipeline. Default
+\code{"No call date recorded"}.}
+
+\item{label_excl_screen}{Character. Header for the middle screening-exclusion
+box. Default \code{"Excluded"}.}
+
+\item{label_excl_waittime}{Character. Header for the wait-time exclusion box.
+Default \code{"No appointment date\\n(not offered or pending)"}.}
 
 \item{title}{Character. Plot title.}
 


### PR DESCRIPTION
## Summary
`mysterycall_flow_diagram()` and `mysterycall_strobe_flow()` hardcoded mystery-caller wording (box headers and exclusion-box labels), so they couldn't be repurposed for a non–call-log pipeline without the figure reading "Calls completed" or "No call date recorded". This adds **backward-compatible label-override arguments** so the same functions can draw any CONSORT/STROBE-style waterfall.

## Changes
- **`mysterycall_flow_diagram()`** — new args: `label_identified`, `label_contacted`, `label_completed`, `label_analysed`, `label_excluded`.
- **`mysterycall_strobe_flow()`** — new args: `label_excl_calldate`, `label_excl_screen`, `label_excl_waittime` (the main box labels — `label_total`/`label_calldate`/`label_included`/`label_logistic`/`label_waittime` — were already overridable).
- roxygen `@param` docs + regenerated `.Rd` for both.

## Backward compatibility
All new args default to the existing mystery-caller wording, so **output is byte-identical when the args are omitted**. No behavior change for current callers.

## Verification
Re-rendered a non–call-log pipeline (an OB/GYN subspecialist workforce cohort) with the overrides: `flow_diagram` now reads "ABOG board-certified physicians → Matched to a valid NPI → Target subspecialists → Final analytic cohort" instead of the call-log wording.

## Note (out of scope)
These are *label* overrides only. `strobe_flow`'s two-outcome terminal fork (logistic + wait-time) is structural; a strictly linear pipeline still renders a second terminal box. Restructuring that fork would be a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)