### PR TITLE
fix: clear three pre-existing CI failures (compare_waves, overdispersion snapshot, pkgdown index)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # mysterycall 1.6.3.9000 (development version)
 
+## Bug fixes
+
+- `mysterycall_compare_waves()` now returns an `iqr` (interquartile range)
+  column for continuous outcomes, alongside the existing `q1` / `q3`, matching
+  its documented headline statistics and the test expectations.
+- Refreshed the `mysterycall_overdispersion_sentence()` test snapshot to match
+  the graduated "Mild overdispersion" wording the function now emits.
+- Added the 68 documented-but-unindexed topics (datasets, `print()` /
+  `as.data.frame()` methods, and additional exported functions) to the pkgdown
+  reference index so `pkgdown::build_site()` no longer errors on missing topics.
+
 ## Census geography vintage
 
 The 2020 Census redrew tracts, block groups, and ZCTAs. Several paths could

--- a/R/compare_waves.R
+++ b/R/compare_waves.R
@@ -19,7 +19,7 @@
 #' @return A data frame. For proportion outcomes: columns `wave`,
 #'   (`group`,) `n`, `n_accepted`, `rate`, `lower_ci`, `upper_ci`,
 #'   `p_vs_ref`. For continuous outcomes: columns `wave`, (`group`,)
-#'   `n`, `mean`, `median`, `sd`, `q1`, `q3`, `p_vs_ref`. The `group`
+#'   `n`, `mean`, `median`, `sd`, `iqr`, `q1`, `q3`, `p_vs_ref`. The `group`
 #'   column is only present when `group_col` is non-`NULL`. The
 #'   attribute `ref_wave` is set on the returned data frame.
 #'
@@ -136,6 +136,7 @@ mysterycall_compare_waves <- function(
       mean     = if (n > 0) mean(y)   else NA_real_,
       median   = if (n > 0) stats::median(y) else NA_real_,
       sd       = if (n > 0) stats::sd(y)     else NA_real_,
+      iqr      = if (n > 0) stats::IQR(y, na.rm = TRUE) else NA_real_,
       q1       = if (n > 0) stats::quantile(y, 0.25, names = FALSE) else NA_real_,
       q3       = if (n > 0) stats::quantile(y, 0.75, names = FALSE) else NA_real_,
       p_vs_ref = NA_real_,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -68,6 +68,10 @@ reference:
       - medicaid_fee_index
       - physicians
       - taxonomy
+      - adi_zcta
+      - svi_zcta
+      - zcta_tract_xwalk
+      - healthgrades_ages
 
   - title: "Provider Search and NPI"
     desc: >
@@ -724,6 +728,80 @@ reference:
       - prepare_calls
       - results_report
       - strobe_flow
+
+  - title: "Additional Functions"
+    desc: >
+      Further analysis, power, workflow, and utility functions.
+    contents:
+      - mysterycall_adjusted_power
+      - mysterycall_appointment_obtained
+      - mysterycall_assign_area_covariates
+      - mysterycall_categorize_wait
+      - mysterycall_clean_zip
+      - mysterycall_exclusion_crosswalk
+      - mysterycall_flag_near_duplicate_keys
+      - mysterycall_gee
+      - mysterycall_geocode_address
+      - mysterycall_link_physicians
+      - mysterycall_lm_interaction_power
+      - mysterycall_lookup_age
+      - mysterycall_nppes_gender
+      - mysterycall_overdispersion_threshold
+      - mysterycall_parse_duration
+      - mysterycall_plot_paired_slope
+      - mysterycall_plot_raincloud
+      - mysterycall_reached_declined_reasons
+      - mysterycall_read_latest
+      - mysterycall_reconcile_inclusion
+      - mysterycall_scenario_coverage
+      - mysterycall_ttest_power
+      - logging-utils
+      - preflight-checks
+      - progress-bars
+
+  - title: "S3 Methods"
+    desc: >
+      print() and as.data.frame() methods for mysterycall result objects.
+    contents:
+      - as.data.frame.mysterycall_access_cascade
+      - as.data.frame.mysterycall_concordance
+      - as.data.frame.mysterycall_consistency_report
+      - as.data.frame.mysterycall_cumulative_access_curve
+      - as.data.frame.mysterycall_hurdle_wait
+      - as.data.frame.mysterycall_joint_test
+      - as.data.frame.mysterycall_leave_one_out
+      - as.data.frame.mysterycall_marginal_power
+      - as.data.frame.mysterycall_matched_controls
+      - as.data.frame.mysterycall_multiresponse
+      - as.data.frame.mysterycall_offer_reconciliation
+      - as.data.frame.mysterycall_outcome_bounds
+      - as.data.frame.mysterycall_paired_mcnemar
+      - as.data.frame.mysterycall_paired_wait
+      - as.data.frame.mysterycall_rank_comparison
+      - as.data.frame.mysterycall_twopart_power
+      - print.mysterycall_access_cascade
+      - print.mysterycall_categorical_test
+      - print.mysterycall_cmh_test
+      - print.mysterycall_concordance
+      - print.mysterycall_consistency_report
+      - print.mysterycall_crisp_checklist
+      - print.mysterycall_cumulative_access_curve
+      - print.mysterycall_exclusion_summary
+      - print.mysterycall_hurdle_wait
+      - print.mysterycall_joint_test
+      - print.mysterycall_leave_one_out
+      - print.mysterycall_marginal_power
+      - print.mysterycall_matched_controls
+      - print.mysterycall_multiresponse
+      - print.mysterycall_offer_reconciliation
+      - print.mysterycall_outcome_bounds
+      - print.mysterycall_paired_mcnemar
+      - print.mysterycall_paired_wait
+      - print.mysterycall_rank_comparison
+      - print.mysterycall_reconciliation
+      - print.mysterycall_rubric
+      - print.mysterycall_simple_poisson
+      - print.mysterycall_twopart_power
 
   - title: "Deprecated"
     contents:

--- a/man/mysterycall_compare_waves.Rd
+++ b/man/mysterycall_compare_waves.Rd
@@ -36,7 +36,7 @@ alphabetically/numerically) is used.}
 A data frame. For proportion outcomes: columns \code{wave},
 (\code{group},) \code{n}, \code{n_accepted}, \code{rate}, \code{lower_ci}, \code{upper_ci},
 \code{p_vs_ref}. For continuous outcomes: columns \code{wave}, (\code{group},)
-\code{n}, \code{mean}, \code{median}, \code{sd}, \code{q1}, \code{q3}, \code{p_vs_ref}. The \code{group}
+\code{n}, \code{mean}, \code{median}, \code{sd}, \code{iqr}, \code{q1}, \code{q3}, \code{p_vs_ref}. The \code{group}
 column is only present when \code{group_col} is non-\code{NULL}. The
 attribute \code{ref_wave} is set on the returned data frame.
 }

--- a/tests/testthat/_snaps/snapshot-sentences.md
+++ b/tests/testthat/_snaps/snapshot-sentences.md
@@ -87,7 +87,7 @@
     Code
       result$sentence
     Output
-      [1] "The Pearson dispersion ratio is 1.25 (chi-square = 72.68, df = 58, p = 0.093). No significant overdispersion detected (ratio = 1.25). The Poisson model appears adequate."
+      [1] "The Pearson dispersion ratio is 1.25 (chi-square = 72.68, df = 58, p = 0.093). Mild overdispersion detected (ratio = 1.25), below the negative-binomial switch threshold; the Poisson model may still be adequate."
 
 # mysterycall_r2_sentence sentence snapshot
 


### PR DESCRIPTION
## Summary

`main` has had three CI failures that block every PR (including #195). None relate to any feature work — they're standalone breakages. This PR fixes all three so CI can go green.

## Changes

**1. `test-coverage` — `mysterycall_compare_waves()` missing `iqr`** (`test-cov-compare_waves.R:62/74/209`)
The continuous-outcome branch returned `q1`/`q3` but not the `iqr` the tests (and the function's headline stats) expect. Added an `iqr` column (`stats::IQR`) alongside `q1`/`q3`, and updated `@return`.

**2. `test-coverage` — overdispersion sentence snapshot drift** (`test-snapshot-sentences.R:149`)
`mysterycall_overdispersion_sentence()` was upgraded to graduated wording ("Mild overdispersion detected … below the negative-binomial switch threshold") but the snapshot was never regenerated. Refreshed the snapshot to the current output. No behavior change — snapshot only.

**3. `pkgdown` — 65+ topics missing from the reference index**
`pkgdown::build_site()` errored because documented, exported topics weren't in `_pkgdown.yml`. Added the 68 truly-unindexed topics: the four ZCTA/age datasets into "Data and Datasets", and new "Additional Functions" and "S3 Methods" sections for the exported functions and the `print()` / `as.data.frame()` methods. Verified programmatically that 0 documented non-internal topics remain unindexed and the YAML still parses.

## Verification

- `git diff` is limited to the three broken areas; no feature code touched.
- pkgdown: a script enumerating every `man/*.Rd` topic (respecting `\keyword{internal}` and aliases) reports **0** remaining missing after the change.
- `compare_waves`: no test asserts an exact column set or count for the continuous output (only `%in%` subset checks), so adding `iqr` is safe; nothing else in the package consumes `compare_waves`'s `q1`/`q3`.

## Checklist

- [ ] `devtools::check()` passes with 0 ERRORs and 0 WARNINGs — **not run in this environment (no R available); please verify in CI**
- [x] New/changed behaviour is covered by tests — the three previously-failing tests now match the code
- [x] `NEWS.md` updated (Bug fixes section)
- [x] Documentation updated — `man/mysterycall_compare_waves.Rd` `@return` reflects `iqr`
- [ ] Examples run without error — **not run here**

### Note
R was not runnable in the authoring environment, so this is validated by structure + the failing tests now matching the code; CI on this PR is the real gate. Merging this first should also unblock #195's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYF26RbcWj3dJU4MojYFX)_