### PR TITLE
test: semantic and adversarial tests for subspecialist-density figures

### DIFF
--- a/tests/testthat/test-subspecialist-adversarial.R
+++ b/tests/testthat/test-subspecialist-adversarial.R
@@ -1,0 +1,164 @@
+library(testthat)
+
+# Adversarial tests: hostile / degenerate inputs that should either be handled
+# gracefully or rejected with a clear error — never a silent wrong answer.
+
+FP3 <- c(`2013` = 1e6, `2014` = 1e6, `2015` = 1e6)
+
+# ---- trend: degenerate but valid inputs ------------------------------------
+test_that("trend tolerates an all-zero-count series (density 0, CI lower 0)", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "Z", year = c(2013L, 2014L, 2015L),
+                       count = c(0, 0, 0))
+  p <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = FP3,
+                                                        conf_level = 0.95))
+  expect_true(all(p$data$density == 0))
+  expect_true(all(p$data$density_low == 0))
+  expect_true(all(p$data$density_high >= 0))
+})
+
+test_that("trend tolerates non-integer counts", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L, 2015L),
+                       count = c(10.5, 12.25, 14.0))
+  p <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = FP3,
+                                                        trend_test = "poisson"))
+  expect_s3_class(p, "ggplot")
+  expect_equal(p$data$density[p$data$year == 2013], 10.5 / 1e6 * 1e5)
+})
+
+test_that("trend accepts a population superset (extra years ignored)", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(5, 6))
+  pop <- c(`2011` = 9e5, `2013` = 1e6, `2014` = 1e6, `2020` = 1.1e6)
+  p <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = pop))
+  expect_equal(nrow(p$data), 2L)
+  expect_equal(p$data$population, c(1e6, 1e6))
+})
+
+test_that("trend keeps duplicate subspecialty-year rows without error", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = rep("A", 4),
+                       year = c(2013L, 2013L, 2014L, 2014L),
+                       count = c(5, 7, 6, 8))
+  p <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = FP3))
+  expect_s3_class(p, "ggplot")
+  expect_equal(nrow(p$data), 4L)
+})
+
+test_that("trend: a single-year subspecialty yields an NA trend-test row", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "Solo", year = 2013L, count = 100)
+  p <- suppressWarnings(mysterycall_subspecialist_trend(
+    counts, population = c(`2013` = 1e6), trend_test = "quasipoisson",
+    conf_level = 0.9))
+  tt <- attr(p, "trend_test")
+  expect_true(is.na(tt$rr_per_year))
+  expect_equal(tt$n_years, 1L)
+})
+
+# ---- trend: inputs that must be rejected ------------------------------------
+test_that("trend errors when a needed denominator year is missing", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2099L), count = c(5, 6))
+  expect_error(
+    mysterycall_subspecialist_trend(counts, population = FP3),
+    "missing denominators"
+  )
+})
+
+test_that("trend rejects non-positive population and negative counts", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(5, 6))
+  expect_error(
+    mysterycall_subspecialist_trend(counts, population = c(`2013` = 1e6, `2014` = 0)),
+    "positive"
+  )
+  bad <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(-1, 6))
+  expect_error(mysterycall_subspecialist_trend(bad, population = FP3), "non-negative")
+})
+
+test_that("trend rejects an out-of-range conf_level", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(5, 6))
+  expect_error(
+    mysterycall_subspecialist_trend(counts, population = FP3, conf_level = 0),
+    "conf_level"
+  )
+  expect_error(
+    mysterycall_subspecialist_trend(counts, population = FP3, conf_level = 1.5),
+    "conf_level"
+  )
+})
+
+# ---- infographic: hostile inputs -------------------------------------------
+test_that("infographic renders with NA density (marks it, does not crash)", {
+  skip_if_not_installed("ggplot2")
+  p <- suppressWarnings(mysterycall_subspecialist_infographic(
+    subspecialty = c("A", "B"), start = c(NA, 1), end = c(2, 3), caption = NA))
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("infographic handles one and many subspecialties", {
+  skip_if_not_installed("ggplot2")
+  expect_s3_class(
+    suppressWarnings(mysterycall_subspecialist_infographic(
+      subspecialty = "Only", start = 1, end = 2, caption = NA)),
+    "ggplot")
+  n <- 8L
+  expect_s3_class(
+    suppressWarnings(mysterycall_subspecialist_infographic(
+      subspecialty = paste0("S", seq_len(n)),
+      start = seq_len(n), end = seq_len(n) + 1, caption = NA)),
+    "ggplot")
+})
+
+test_that("infographic rejects length-mismatched and negative inputs", {
+  skip_if_not_installed("ggplot2")
+  expect_error(
+    mysterycall_subspecialist_infographic(subspecialty = c("A", "B"),
+                                          start = c(1, 2), end = 3),
+    "same length")
+  expect_error(
+    mysterycall_subspecialist_infographic(subspecialty = "A", start = -1, end = 2),
+    "non-negative")
+})
+
+test_that(".abbrev_subspecialty survives empty, letterless, and long names", {
+  expect_equal(mysterycall:::.abbrev_subspecialty(""), "")
+  expect_equal(mysterycall:::.abbrev_subspecialty("123 !!!"), "")
+  expect_equal(mysterycall:::.abbrev_subspecialty("A B C D E F"), "ABCD")  # capped at 4
+})
+
+# ---- census fetcher: adversarial (mocked, no network) ----------------------
+test_that("census fetch preserves input year order and names", {
+  skip_if_not_installed("mockery")
+  mockery::stub(mysterycall_census_female_population, ".census_acs_total",
+                function(variable, year, survey, geography) year * 10)
+  out <- suppressMessages(
+    mysterycall_census_female_population(c(2015, 2013, 2014), survey = "acs5"))
+  expect_named(out, c("2015", "2013", "2014"))        # order preserved, not sorted
+  expect_equal(unname(out), c(20150, 20130, 20140))
+})
+
+test_that("census fetch wraps a backend error with the offending year", {
+  skip_if_not_installed("mockery")
+  mockery::stub(mysterycall_census_female_population, ".census_acs_total",
+                function(variable, year, survey, geography) stop("backend down"))
+  expect_error(
+    suppressMessages(mysterycall_census_female_population(2013, survey = "acs5")),
+    "Census fetch for 2013"
+  )
+})
+
+# ---- provenance: prints/captions safely with only required fields ----------
+test_that("provenance prints and captions with all-optional fields absent", {
+  prov <- mysterycall:::.build_provenance(
+    metric = "m", computation = "c", numerator_desc = "num", denominator_desc = "den",
+    generated_by = "g")
+  expect_output(print(prov), "figure provenance")
+  cap <- mysterycall:::.provenance_caption(prov)
+  expect_match(cap, "^Source")
+  expect_match(cap, "num")
+  expect_match(cap, "den")
+})

--- a/tests/testthat/test-subspecialist-bva.R
+++ b/tests/testthat/test-subspecialist-bva.R
@@ -1,0 +1,129 @@
+library(testthat)
+
+# Boundary Value Analysis: exercise each input domain at its edges and the
+# values just inside / just outside them.
+
+.bva_labels <- function(p) {
+  out <- character(0)
+  for (l in p$layers) {
+    lab <- l$aes_params$label
+    if (!is.null(lab)) out <- c(out, as.character(lab))
+    d <- l$data
+    if (is.data.frame(d) && "label" %in% names(d)) out <- c(out, as.character(d$label))
+  }
+  out
+}
+
+FP2 <- c(`2013` = 1e6, `2014` = 1e6)
+FP3 <- c(`2013` = 1e6, `2014` = 1e6, `2015` = 1e6)
+
+# ---- conf_level: open interval (0, 1) --------------------------------------
+test_that("conf_level exactly at the boundaries 0 and 1 is rejected", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(5, 6))
+  expect_error(mysterycall_subspecialist_trend(counts, population = FP2, conf_level = 0), "conf_level")
+  expect_error(mysterycall_subspecialist_trend(counts, population = FP2, conf_level = 1), "conf_level")
+})
+
+test_that("conf_level just inside 0 and 1 gives an ordered CI bracketing the rate", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L, 2015L),
+                       count = c(10, 20, 40))
+  for (cl in c(0.001, 0.5, 0.999)) {
+    d <- suppressWarnings(
+      mysterycall_subspecialist_trend(counts, population = FP3, conf_level = cl))$data
+    expect_true(all(d$density_low <= d$density_high), info = paste("cl", cl))
+    expect_true(all(d$density_low <= d$density & d$density <= d$density_high),
+                info = paste("cl", cl))
+  }
+})
+
+# ---- count: 0 (minimum) and 1 (smallest positive) --------------------------
+test_that("Poisson rate CI at count boundaries 0 and 1", {
+  ci0 <- mysterycall:::.poisson_rate_ci(0, 1e5, 1e5, 0.95)
+  expect_equal(ci0$lower, 0)                                           # defined as 0
+  expect_equal(ci0$upper, stats::qgamma(0.975, shape = 1), tolerance = 1e-8)
+
+  ci1 <- mysterycall:::.poisson_rate_ci(1, 1e5, 1e5, 0.95)
+  expect_equal(ci1$lower, stats::qgamma(0.025, shape = 1), tolerance = 1e-8)
+  expect_equal(ci1$upper, stats::qgamma(0.975, shape = 2), tolerance = 1e-8)
+  expect_gt(ci1$lower, 0)                                              # positive once count >= 1
+})
+
+# ---- population: 1 (smallest positive) and 0 (rejected) --------------------
+test_that("population boundary: 1 gives density = count * per; 0 is rejected", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(3, 4))
+  p <- suppressWarnings(
+    mysterycall_subspecialist_trend(counts, population = c(`2013` = 1, `2014` = 1)))
+  expect_equal(p$data$density, c(3, 4) * 1e5)
+  expect_error(
+    mysterycall_subspecialist_trend(counts, population = c(`2013` = 1, `2014` = 0)),
+    "positive")
+})
+
+# ---- per: boundary value 1 (density is a raw proportion) -------------------
+test_that("per = 1 makes density a raw proportion", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(1234, 4321))
+  pop <- c(`2013` = 2e6, `2014` = 4e6)
+  p <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = pop, per = 1))
+  expect_equal(p$data$density, c(1234 / 2e6, 4321 / 4e6))
+})
+
+# ---- trend_test: number-of-years boundary 1 / 2 / 3 ------------------------
+test_that("trend_test across the minimum-years boundary (1, 2, 3)", {
+  skip_if_not_installed("ggplot2")
+  mk <- function(yrs, cnt) data.frame(subspecialty = "A", year = as.integer(yrs), count = cnt)
+
+  # 1 year: slope undefined -> all-NA row
+  tt1 <- attr(suppressWarnings(mysterycall_subspecialist_trend(
+    mk(2013, 100), population = c(`2013` = 1e6), trend_test = "poisson")), "trend_test")
+  expect_true(is.na(tt1$rr_per_year))
+  expect_equal(tt1$n_years, 1L)
+
+  # 2 years: Poisson slope is defined (Wald z)
+  tt2 <- attr(suppressWarnings(mysterycall_subspecialist_trend(
+    mk(c(2013, 2014), c(100, 110)), population = FP2, trend_test = "poisson")), "trend_test")
+  expect_true(is.finite(tt2$rr_per_year))
+  expect_equal(tt2$n_years, 2L)
+
+  # 3 years: quasipoisson dispersion becomes estimable (residual df = 1)
+  tt3 <- attr(suppressWarnings(mysterycall_subspecialist_trend(
+    mk(2013:2015, c(100, 110, 121)), population = FP3, trend_test = "quasipoisson")), "trend_test")
+  expect_true(is.finite(tt3$rr_per_year))
+  expect_equal(tt3$n_years, 3L)
+})
+
+# ---- infographic percent change: zero-baseline and 100% drop boundaries ----
+test_that("infographic percent-change edges: start=0, end=0, and just above 0", {
+  skip_if_not_installed("ggplot2")
+  z <- suppressWarnings(mysterycall_subspecialist_infographic(
+    subspecialty = "A", start = 0, end = 5, caption = NA))
+  expect_true(any(grepl("n/a", .bva_labels(z), fixed = TRUE)))          # start = 0
+
+  drop <- suppressWarnings(mysterycall_subspecialist_infographic(
+    subspecialty = "A", start = 5, end = 0, caption = NA))
+  expect_true(any(grepl("-100.0%", .bva_labels(drop), fixed = TRUE)))   # end = 0 -> full drop
+
+  tiny <- suppressWarnings(mysterycall_subspecialist_infographic(
+    subspecialty = "A", start = 1e-9, end = 2e-9, caption = NA))
+  expect_true(any(grepl("+100.0%", .bva_labels(tiny), fixed = TRUE)))   # just above the boundary
+})
+
+# ---- infographic digits: boundary value 0 ----------------------------------
+test_that("infographic digits = 0 rounds density values to whole numbers", {
+  skip_if_not_installed("ggplot2")
+  p <- suppressWarnings(mysterycall_subspecialist_infographic(
+    subspecialty = "A", start = 1.44, end = 1.56, digits = 0, caption = NA))
+  labs <- .bva_labels(p)
+  expect_true(any(labs == "1"))    # start rounded down
+  expect_true(any(labs == "2"))    # end rounded up
+})
+
+# ---- abbreviation length cap: boundary at 4 --------------------------------
+test_that(".abbrev_subspecialty caps derived initials at exactly 4", {
+  expect_equal(mysterycall:::.abbrev_subspecialty("Alpha Beta Gamma Delta"), "ABGD")          # 4 words -> 4
+  expect_equal(nchar(mysterycall:::.abbrev_subspecialty("Alpha Beta Gamma Delta")), 4L)
+  expect_equal(mysterycall:::.abbrev_subspecialty("Alpha Beta Gamma Delta Epsilon"), "ABGD")  # 5 -> capped
+})

--- a/tests/testthat/test-subspecialist-semantic.R
+++ b/tests/testthat/test-subspecialist-semantic.R
@@ -1,0 +1,143 @@
+library(testthat)
+
+# Semantic tests: assert the actual numbers the density functions compute, not
+# just their structure. Values are checked against closed-form ground truth.
+
+# Collect drawn text from a ggplot: annotate() stores `label` in aes_params,
+# geom_text() in the layer data — check both.
+.sem_labels <- function(p) {
+  out <- character(0)
+  for (l in p$layers) {
+    lab <- l$aes_params$label
+    if (!is.null(lab)) out <- c(out, as.character(lab))
+    d <- l$data
+    if (is.data.frame(d) && "label" %in% names(d)) out <- c(out, as.character(d$label))
+  }
+  out
+}
+
+# ---- density == count / population * per, exactly --------------------------
+test_that("trend density equals count / population * per, to the digit", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2023L),
+                       count = c(1234, 4321))
+  pop <- c(`2013` = 2e6, `2023` = 4e6)
+  p <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = pop))
+  d <- p$data
+  expect_equal(d$density[d$year == 2013], 1234 / 2e6 * 1e5)   # 61.7
+  expect_equal(d$density[d$year == 2023], 4321 / 4e6 * 1e5)   # 108.025
+  # every row satisfies the identity
+  expect_equal(d$density, d$count / d$population * 1e5)
+})
+
+test_that("density scales linearly with `per`", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(100, 200))
+  pop <- c(`2013` = 1e6, `2014` = 1e6)
+  p5 <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = pop, per = 1e5))
+  p3 <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = pop, per = 1e3))
+  expect_equal(p5$data$density, p3$data$density * 100)
+})
+
+# ---- exact Garwood Poisson confidence limits -------------------------------
+test_that("Poisson rate CI matches the exact Garwood/gamma limits", {
+  # per == population, so rate limits equal count limits
+  ci5 <- mysterycall:::.poisson_rate_ci(5, 1e5, 1e5, 0.95)
+  expect_equal(ci5$lower, stats::qgamma(0.025, shape = 5), tolerance = 1e-8)
+  expect_equal(ci5$upper, stats::qgamma(0.975, shape = 6), tolerance = 1e-8)
+
+  ci0 <- mysterycall:::.poisson_rate_ci(0, 1e5, 1e5, 0.95)
+  expect_equal(ci0$lower, 0)                                             # defined as 0
+  expect_equal(ci0$upper, stats::qgamma(0.975, shape = 1), tolerance = 1e-8)
+
+  # 90% interval is strictly inside the 95% interval
+  a95 <- mysterycall:::.poisson_rate_ci(20, 1e5, 1e5, 0.95)
+  a90 <- mysterycall:::.poisson_rate_ci(20, 1e5, 1e5, 0.90)
+  expect_gt(a90$lower, a95$lower)
+  expect_lt(a90$upper, a95$upper)
+})
+
+test_that("Poisson rate CI scales inversely with the denominator", {
+  a <- mysterycall:::.poisson_rate_ci(20, 1e5, 1e5, 0.95)
+  b <- mysterycall:::.poisson_rate_ci(20, 2e5, 1e5, 0.95)   # double the population
+  expect_equal(b$lower, a$lower / 2, tolerance = 1e-10)
+  expect_equal(b$upper, a$upper / 2, tolerance = 1e-10)
+})
+
+test_that("conf_level CI band brackets the point rate for every row", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = rep(c("A", "B"), each = 3),
+                       year = rep(c(2013L, 2018L, 2023L), 2),
+                       count = c(5, 40, 200, 0, 1, 3))
+  pop <- c(`2013` = 1e6, `2018` = 1e6, `2023` = 1e6)
+  p <- suppressWarnings(mysterycall_subspecialist_trend(counts, population = pop,
+                                                        conf_level = 0.95))
+  d <- p$data
+  expect_true(all(d$density_low <= d$density & d$density <= d$density_high))
+  expect_true(all(d$density_low >= 0))
+})
+
+# ---- trend_test recovers a known rate ratio --------------------------------
+test_that("trend_test recovers the true annual rate ratio on log-linear data", {
+  skip_if_not_installed("ggplot2")
+  r <- 1.08; base <- 1000; yrs <- 2013:2023
+  # counts sit exactly on base * r^(year - 2013); Poisson MLE recovers b = log(r)
+  counts <- data.frame(subspecialty = "A", year = yrs,
+                       count = base * r^(yrs - 2013))
+  pop <- stats::setNames(rep(1e6, length(yrs)), yrs)
+  p <- suppressWarnings(
+    mysterycall_subspecialist_trend(counts, population = pop, trend_test = "poisson")
+  )
+  tt <- attr(p, "trend_test")
+  expect_equal(tt$rr_per_year, r, tolerance = 1e-4)
+  expect_lt(tt$p_value, 1e-3)
+  # internal consistency of the derived percentages
+  span <- diff(range(yrs))
+  expect_equal(tt$pct_per_year, (tt$rr_per_year - 1) * 100, tolerance = 1e-8)
+  expect_equal(tt$pct_total, (tt$rr_per_year^span - 1) * 100, tolerance = 1e-8)
+})
+
+test_that("trend_test reports rate ratio ~1 for a flat series", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "Flat", year = 2013:2020,
+                       count = rep(500, 8))
+  pop <- stats::setNames(rep(1e6, 8), 2013:2020)
+  tt <- attr(suppressWarnings(
+    mysterycall_subspecialist_trend(counts, population = pop, trend_test = "poisson")
+  ), "trend_test")
+  expect_equal(tt$rr_per_year, 1, tolerance = 1e-8)
+  expect_equal(tt$pct_total, 0, tolerance = 1e-6)
+})
+
+# ---- infographic percent change is exact -----------------------------------
+test_that("infographic percent change is exact across cases", {
+  skip_if_not_installed("ggplot2")
+  lab <- function(s, e) suppressWarnings(.sem_labels(
+    mysterycall_subspecialist_infographic(subspecialty = "X", start = s, end = e,
+                                          caption = NA)))
+  expect_true(any(grepl("+12.5%",  lab(0.8, 0.9), fixed = TRUE)))
+  expect_true(any(grepl("+200.0%", lab(1,   3),   fixed = TRUE)))
+  expect_true(any(grepl("-50.0%",  lab(2,   1),   fixed = TRUE)))
+  expect_true(any(grepl("+0.0%",   lab(2,   2),   fixed = TRUE)))   # no change
+  expect_true(any(grepl("n/a",     lab(0,   5),   fixed = TRUE)))   # zero baseline
+})
+
+test_that("infographic colours a decrease with the decrease colour", {
+  skip_if_not_installed("ggplot2")
+  p <- suppressWarnings(mysterycall_subspecialist_infographic(
+    subspecialty = c("Up", "Down"), start = c(1, 2), end = c(2, 1), caption = NA))
+  all_cols <- unlist(lapply(p$layers, function(l) l$aes_params$colour))
+  expect_true("#B22222" %in% all_cols)    # decrease_color is used only for drops
+})
+
+# ---- provenance records the exact computation ------------------------------
+test_that("provenance records the exact computation string and scale", {
+  skip_if_not_installed("ggplot2")
+  counts <- data.frame(subspecialty = "A", year = c(2013L, 2014L), count = c(1, 2))
+  p <- suppressWarnings(mysterycall_subspecialist_trend(
+    counts, population = c(`2013` = 1e6, `2014` = 1e6), per = 1e5))
+  prov <- attr(p, "provenance")
+  expect_match(prov$computation, "count / population * 100000", fixed = TRUE)
+  expect_equal(prov$per, 1e5)
+  expect_equal(prov$years, c(2013, 2014))
+})


### PR DESCRIPTION
## Summary

The existing subspecialist-density tests mostly assert structure (class, column presence). This adds two files that assert **meaning** and **robustness**, verifying the functions merged in #202.

## Changes

**`test-subspecialist-semantic.R`** — assert the actual numbers against closed-form ground truth:
- `density == count / population * per`, to the digit, and linear in `per`.
- Exact Garwood/gamma Poisson CI limits (`qgamma`), 90% interval strictly inside 95%, CI scales inversely with the denominator, band brackets every point rate.
- `trend_test` recovers the *true* annual rate ratio on log-linear data (Poisson MLE → `log(r)` exactly); `pct_per_year`/`pct_total` are internally consistent; a flat series → rate ratio 1.
- Infographic percent change exact across increase / decrease / no-change / zero-baseline; a decrease is drawn with the decrease colour.
- Provenance records the exact computation string, per-scale, and year range.

**`test-subspecialist-adversarial.R`** — hostile/degenerate inputs are handled or clearly rejected (never a silent wrong answer):
- All-zero-count series, non-integer counts, population **superset**, duplicate subspecialty-year rows, single-year series → NA trend row.
- Rejects a missing denominator year, non-positive population, negative counts, out-of-range `conf_level`, length-mismatched infographic inputs.
- Infographic renders with NA density; handles 1 and 8 subspecialties.
- `.abbrev_subspecialty` on empty / letterless / long names.
- Census fetcher (mocked, no network): preserves input year order, wraps a backend error with the offending year.
- Provenance prints/captions safely with only the required fields.

## Checklist

- [ ] `devtools::check()` passes with 0 ERRORs and 0 WARNINGs — **not run here (no R); CI is the gate**
- [x] New behaviour is covered by tests — this PR *is* tests
- [ ] `NEWS.md` — no user-facing change (tests only), so no entry
- [x] Documentation — n/a (no code/API change)
- [ ] Examples run without error — n/a

### Note
Tests only — no package code changes. Assertions were derived by hand against closed-form values (exact density arithmetic, `qgamma` Poisson limits, Poisson-MLE rate-ratio recovery); CI is the execution gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYF26RbcWj3dJU4MojYFX)_