### PR TITLE
fix: stop run_analysis() emitting a deprecation warning on every run

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Bug fixes
 
+- `mysterycall_run_analysis()` no longer emits a deprecation warning on every
+  run. Its `acceptance_rates` step now calls an internal worker
+  (`.mc_insurance_acceptance_rates()`) instead of the deprecated
+  `mysterycall_insurance_acceptance_rates()`, with identical output. The public
+  deprecated function is unchanged (still works and still warns for external
+  callers).
 - `mysterycall_compare_waves()` now returns an `iqr` (interquartile range)
   column for continuous outcomes, alongside the existing `q1` / `q3`, matching
   its documented headline statistics and the test expectations.

--- a/R/insurance_acceptance_rates.R
+++ b/R/insurance_acceptance_rates.R
@@ -109,6 +109,41 @@ mysterycall_insurance_acceptance_rates <- function(
                 "mysterycall_acceptance_rate_calc(medicaid_screen_group = ",
                 "\"Medicaid\") instead."))
 
+  .mc_insurance_acceptance_rates(
+    data                    = data,
+    insurance_col           = insurance_col,
+    exclusion_col           = exclusion_col,
+    days_col                = days_col,
+    medicaid_accept_col     = medicaid_accept_col,
+    phone_col               = phone_col,
+    contact_value           = contact_value,
+    reached_declined_values = reached_declined_values,
+    medicaid_label          = medicaid_label,
+    bcbs_label              = bcbs_label,
+    digits                  = digits,
+    output_dir              = output_dir,
+    filename                = filename)
+}
+
+# Internal worker: the identical acceptance-rate computation and manuscript
+# paragraph, WITHOUT the deprecation warning, so in-package callers (e.g.
+# mysterycall_run_analysis) reuse it without tripping .Deprecated(). Keep the
+# signature and defaults in lock-step with the exported wrapper above.
+.mc_insurance_acceptance_rates <- function(
+    data,
+    insurance_col       = "insurance",
+    exclusion_col       = "reason_for_exclusions",
+    days_col            = "business_days_until_appointment",
+    medicaid_accept_col = "does_the_physician_accept_medicaid",
+    phone_col           = "phone",
+    contact_value       = "Able to contact",
+    reached_declined_values = mysterycall_reached_declined_reasons(),
+    medicaid_label      = "Medicaid",
+    bcbs_label          = "Blue Cross/Blue Shield",
+    digits              = 1L,
+    output_dir          = NULL,
+    filename            = "insurance_acceptance_rates.csv") {
+
   # -- Validate inputs ----------------------------------------------------------
   checkmate::assert_data_frame(data, min.rows = 0)
   checkmate::assert_string(insurance_col)

--- a/R/run_analysis.R
+++ b/R/run_analysis.R
@@ -315,7 +315,10 @@ mysterycall_run_analysis <- function(
     required_ar <- c(insurance_col, exclusion_col, outcome_col, phone_col)
     if (all(required_ar %in% names(current_data))) {
       results[["acceptance_rates"]] <- .try("acceptance_rates", {
-        mysterycall_insurance_acceptance_rates(
+        # Internal worker (not the deprecated public wrapper) so the workflow
+        # reuses the exact same computation without emitting a deprecation
+        # warning on every run. See R/insurance_acceptance_rates.R.
+        .mc_insurance_acceptance_rates(
           data           = current_data,
           insurance_col  = insurance_col,
           exclusion_col  = exclusion_col,

--- a/tests/testthat/test-run-analysis-no-deprecation.R
+++ b/tests/testthat/test-run-analysis-no-deprecation.R
@@ -1,0 +1,46 @@
+library(testthat)
+
+# mysterycall_run_analysis() used to call the deprecated
+# mysterycall_insurance_acceptance_rates() internally, emitting a deprecation
+# warning on every run (hundreds across the test suite). It now calls the
+# non-deprecated internal worker .mc_insurance_acceptance_rates() with identical
+# behaviour. These tests pin that: the workflow is quiet, the public wrapper
+# still warns for external callers, and the two paths return the same object.
+
+DF <- data.frame(
+  insurance                          = rep(c("Medicaid", "Blue Cross/Blue Shield"), 3),
+  reason_for_exclusions              = rep("Able to contact", 6),
+  business_days_until_appointment    = c(5, 8, 3, 10, 7, 6),
+  phone                              = c("3035550100", "3035550100", "7205550200",
+                                         "7205550200", "3035550300", "3035550300"),
+  does_the_physician_accept_medicaid = rep("Yes", 6),
+  stringsAsFactors = FALSE
+)
+
+test_that("run_analysis acceptance_rates step emits no deprecation warning", {
+  w <- testthat::capture_warnings(suppressMessages(
+    mysterycall_run_analysis(DF, steps = "acceptance_rates", output_dir = NA,
+                             verbose = FALSE)
+  ))
+  expect_false(any(grepl("deprecated", w, ignore.case = TRUE)),
+               info = paste("warnings seen:", paste(w, collapse = " | ")))
+})
+
+test_that("the internal worker itself does not warn", {
+  expect_no_warning(
+    mysterycall:::.mc_insurance_acceptance_rates(DF, output_dir = NA)
+  )
+})
+
+test_that("the public wrapper is still deprecated (warns) for external callers", {
+  expect_warning(
+    mysterycall_insurance_acceptance_rates(DF, output_dir = NA),
+    "deprecated"
+  )
+})
+
+test_that("worker and deprecated wrapper return identical results", {
+  worker <- mysterycall:::.mc_insurance_acceptance_rates(DF, output_dir = NA)
+  public <- suppressWarnings(mysterycall_insurance_acceptance_rates(DF, output_dir = NA))
+  expect_identical(worker, public)
+})


### PR DESCRIPTION
## Summary

`mysterycall_run_analysis()`'s `acceptance_rates` step called the **deprecated** `mysterycall_insurance_acceptance_rates()` internally, so every workflow run tripped `.Deprecated()` — ~200 deprecation warnings across the test suite (`WARN 204`), drowning any real warning signal.

Fix: extract the computation into a non-deprecated internal worker and have the workflow call that, with **byte-identical** output (same manuscript paragraph).

## Changes

- `R/insurance_acceptance_rates.R`: extract the body into `.mc_insurance_acceptance_rates()`. The exported `mysterycall_insurance_acceptance_rates()` becomes a thin shim — `.Deprecated()` + forward to the worker — so **external callers still get the warning and identical results**. Nothing about the public API changes.
- `R/run_analysis.R`: the `acceptance_rates` step calls `.mc_insurance_acceptance_rates()` directly.
- `tests/testthat/test-run-analysis-no-deprecation.R`: the workflow's acceptance-rates step emits no `deprecated` warning; the worker itself doesn't warn; the public wrapper **still** warns; worker and wrapper return `identical()` objects.
- `NEWS.md`: bug-fix entry.

## Why the worker-extraction (not a call-site `suppressWarnings`)

- Preserves the exact output (`suppressWarnings` at the call site would also hide *real* warnings).
- Keeps the deprecation intact for external users of the public function.
- Confirmed `run_analysis.R:318` was the **only** internal caller (everything else is doc references), and no test asserts the workflow warns.

## Checklist

- [ ] `devtools::check()` passes 0/0 — **not run here (no R); CI is the gate**
- [x] New behaviour covered by tests
- [x] `NEWS.md` updated
- [x] Documentation — n/a (internal worker; public API unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYF26RbcWj3dJU4MojYFX)_