### PR TITLE
chore(deps): trim unused Suggests; move covr/pkgdown to Config/Needs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,6 @@ Suggests:
     DHARMa,
     duckdb,
     digest,
-    easyr,
     effects,
     fastLink,
     emmeans,
@@ -72,7 +71,6 @@ Suggests:
     gtsummary,
     grid,
     gridExtra,
-    htmltools,
     humaniformat,
     jsonlite,
     knitr,
@@ -80,7 +78,6 @@ Suggests:
     maps,
     lmerTest,
     marginaleffects,
-    memoise,
     mice,
     mockery,
     naniar,
@@ -88,7 +85,6 @@ Suggests:
     officer,
     openxlsx,
     patchwork,
-    pkgdown,
     pwr,
     progress,
     purrr,
@@ -100,7 +96,6 @@ Suggests:
     tidycensus,
     tigris,
     tidyr,
-    covr,
     forcats,
     ggmap (>= 3.0.0),
     reformulas,
@@ -113,4 +108,6 @@ Suggests:
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0
+Config/Needs/website: pkgdown
+Config/Needs/coverage: covr
 RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # mysterycall 1.6.3.9000 (development version)
 
+## Dependencies
+
+- Trimmed unused `Suggests`: removed `easyr`, `htmltools`, and `memoise`
+  (no code in the package references them). Moved the dev-tools `covr` and
+  `pkgdown` out of `Suggests` into `Config/Needs/coverage` and
+  `Config/Needs/website` (they are installed explicitly by CI, not needed as
+  runtime suggestions). Net: `Suggests` drops from 62 to 57 packages, lightening
+  `install.packages(dependencies = TRUE)`.
+
 ## Bug fixes
 
 - `mysterycall_run_analysis()` no longer emits a deprecation warning on every


### PR DESCRIPTION
## Summary

Dependency audit. Grepped every `Imports`/`Suggests` package for real usage (`pkg::`, `library/require/requireNamespace`, `@importFrom`) across `R/`, `tests/`, `vignettes/`, `inst/`, `data-raw/`, plus the CI workflows.

## Changes (`DESCRIPTION` only)

- **Removed 3 genuinely-unused Suggests:** `easyr`, `htmltools`, `memoise` — nothing in the package references them. (`memoise`'s only trace was stale glossary *prose* describing an isochrone cache that now lives in the `mysterymaps` package.)
- **Moved `covr` and `pkgdown` out of `Suggests`** into `Config/Needs/coverage` and `Config/Needs/website`. They're dev/CI tools the workflows already install explicitly (`extra-packages: any::covr` / `any::pkgdown`), so they don't belong in runtime `Suggests`. `r-lib/actions/setup-r-dependencies` reads `Config/Needs/*`, so CI is unaffected.

**Net:** `Suggests` drops **62 → 57**, lightening `install.packages("mysterycall", dependencies = TRUE)`.

## What I deliberately did *not* touch

- **All 22 `Imports` are genuinely used** (≥2 references each), so none were removed.
- **Moving an `Import` behind `requireNamespace`** (e.g. `performance`, used in one file) would shrink the hard-dependency set further, but it needs guard code + an actual `R CMD check` run to confirm no load-time use. Deferred as a follow-up rather than guessed at without R.

## Verification

- `DESCRIPTION` re-parsed: `Suggests` well-formed (comma structure intact, no dupes, no dangling last-comma).
- Confirmed `covr`/`pkgdown` are installed by the workflows independent of `Suggests`, so the coverage and pkgdown builds keep working.

## Checklist

- [ ] `devtools::check()` 0/0 — **not run here (no R); CI is the gate**
- [x] No code behaviour change (metadata only)
- [x] `NEWS.md` updated (Dependencies entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYF26RbcWj3dJU4MojYFX)_