### PR TITLE
Harden functions: RNG stream hygiene, locale-independent reproducibility, silent-skip & validation guards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,45 @@
 # mysterycall 1.6.3.9000 (development version)
 
+## Robustness / hardening
+
+- **RNG side-effects removed.** Eleven functions that set a random seed
+  internally (`mysterycall_nb_power()`, `mysterycall_marginal_power()`,
+  `mysterycall_adjusted_power()`, `mysterycall_twopart_power()`,
+  `mysterycall_icc()`, `mysterycall_bootstrap_ci()`,
+  `mysterycall_build_matched_controls()`, `mysterycall_split_and_save()`,
+  `mysterycall_stratified_sample()`, and the internal validation /
+  interaction-screen helpers)
+  now use `withr::local_seed()` instead of `set.seed()`. They remain fully
+  reproducible for a given seed, but no longer clobber the caller's global
+  random-number stream as a side effect.
+- **Locale-independent reproducibility.** The reference-category pick in
+  `mysterycall_nb_model()`, `mysterycall_poisson_model()`,
+  `mysterycall_logistic_model()`, and `mysterycall_lmm()` — and the
+  audit-artifact key ordering shared by `mysterycall_clean_phase1()` and
+  `mysterycall_verify_artifact()` — now sort with `method = "radix"`, so the
+  chosen baseline level and the provenance hash no longer depend on the
+  machine's `LC_COLLATE` locale.
+- **Empty-sequence safety.** Replaced `for (i in 1:n)` with `seq_len(n)` in the
+  internal validation and spatial-density loops so a zero count iterates zero
+  times instead of running backwards.
+- **Silent-skip → warning.** `mysterycall_summarize_demographics()` now warns
+  when a *supplied* `female_col` / `setting_col` is not found in the data
+  (previously it silently returned `NA`, indistinguishable from "not
+  requested").
+- **Input validation.** `mysterycall_wait_time_by_group()` now asserts the
+  outcome column is numeric before computing medians/quantiles.
+- **Optional-dependency guards.** `mysterycall_clean_phase1()` and
+  `mysterycall_verify_artifact()` now include `digest` (and, for the former,
+  `jsonlite`) in their up-front `requireNamespace()` checks — those packages are
+  used unconditionally to build the provenance hash, so a missing one now yields
+  the friendly install message instead of a cryptic error mid-run.
+- **Defensive p-value fallback.** `mysterycall_lmm()` had a dead
+  `if … else "t value"` branch; it now falls back to `NULL` with a downstream
+  guard, returning `NA` p-values rather than erroring if a model summary lacks
+  the t-statistic column.
+- **File output.** `mysterycall_export_results_docx()` now creates the target
+  directory if it does not exist, matching the other writers in the package.
+
 ## Consistency
 
 - P-value formatting is now consistent across the package: a single internal

--- a/R/adjusted_power.R
+++ b/R/adjusted_power.R
@@ -76,7 +76,7 @@ mysterycall_adjusted_power <- function(n_total, rural_frac,
     stop("mysterycall_adjusted_power() requires the glmmTMB package.\n",
          "Install it with: install.packages(\"glmmTMB\")", call. = FALSE)
   }
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) withr::local_seed(seed)
 
   # ICC -> state random-intercept SD on the log scale. Invert the *same*
   # latent-scale decomposition mysterycall_icc() uses, so a run requested at

--- a/R/audit-verify.R
+++ b/R/audit-verify.R
@@ -54,8 +54,9 @@
 #' # Verify an audit file written by clean_phase1
 #' mysterycall_verify_artifact("path/to/audit_trail_2026-05-09.json")
 mysterycall_verify_artifact <- function(audit_path) {
-  if (!requireNamespace("jsonlite", quietly = TRUE)) {
-    stop("Package 'jsonlite' is required",
+  if (!requireNamespace("jsonlite", quietly = TRUE) ||
+      !requireNamespace("digest", quietly = TRUE)) {
+    stop("Packages 'jsonlite' and 'digest' are required",
          call. = FALSE)
   }
   if (!is.character(audit_path) || length(audit_path) != 1L || !nzchar(audit_path)) {
@@ -80,7 +81,7 @@ mysterycall_verify_artifact <- function(audit_path) {
   }
 
   stored_id   <- audit$artifact_id
-  stable_keys <- sort(setdiff(names(audit), c(.audit_volatile_fields, "artifact_id")))
+  stable_keys <- sort(setdiff(names(audit), c(.audit_volatile_fields, "artifact_id")), method = "radix")
   stable_json <- jsonlite::toJSON(audit[stable_keys], auto_unbox = TRUE, digits = NA)
   recomputed  <- digest::digest(as.character(stable_json), algo = "sha256", serialize = FALSE)
 

--- a/R/bootstrap_ci.R
+++ b/R/bootstrap_ci.R
@@ -94,7 +94,7 @@ mysterycall_bootstrap_ci <- function(
 
   # ---- set seed --------------------------------------------------------
   if (!is.null(seed)) {
-    set.seed(seed)
+    withr::local_seed(seed)
   }
 
   # ---- choose statistic function --------------------------------------

--- a/R/clean_phase_1_results.R
+++ b/R/clean_phase_1_results.R
@@ -153,7 +153,9 @@ mysterycall_clean_phase1 <- function(phase1_data,
       !requireNamespace("janitor", quietly = TRUE) ||
       !requireNamespace("readr", quietly = TRUE) ||
       !requireNamespace("stringr", quietly = TRUE) ||
-      !requireNamespace("humaniformat", quietly = TRUE)) {
+      !requireNamespace("humaniformat", quietly = TRUE) ||
+      !requireNamespace("digest", quietly = TRUE) ||
+      !requireNamespace("jsonlite", quietly = TRUE)) {
     stop("Required packages are not installed", call. = FALSE)
   }
 
@@ -501,7 +503,7 @@ mysterycall_clean_phase1 <- function(phase1_data,
   # serialisation to guarantee order-independent stability.
   # .audit_volatile_fields is defined in R/audit-verify.R and shared with
   # mysterycall_verify_artifact() to guarantee identical canonicalization.
-  stable_keys     <- sort(setdiff(names(audit_trail), .audit_volatile_fields))
+  stable_keys     <- sort(setdiff(names(audit_trail), .audit_volatile_fields), method = "radix")
   stable_json     <- jsonlite::toJSON(audit_trail[stable_keys], auto_unbox = TRUE, digits = NA)
   audit_trail$artifact_id <- digest::digest(as.character(stable_json),
                                             algo = "sha256", serialize = FALSE)

--- a/R/data_utils.R
+++ b/R/data_utils.R
@@ -82,7 +82,7 @@ mysterycall_stratified_sample <- function(data, group_col, n_per_group, seed = N
     stop("`n_per_group` must be a single positive integer.", call. = FALSE)
   }
 
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) withr::local_seed(seed)
 
   groups <- split(seq_len(nrow(data)), data[[group_col]])
   idx <- unlist(lapply(groups, function(rows) {

--- a/R/export_results_docx.R
+++ b/R/export_results_docx.R
@@ -94,6 +94,11 @@ mysterycall_export_results_docx <- function(table,
   }
 
   doc <- flextable::body_add_flextable(doc, ft)
+
+  out_dir <- dirname(output_path)
+  if (nzchar(out_dir) && !dir.exists(out_dir)) {
+    dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+  }
   print(doc, target = output_path)
 
   message("Results written to: ", output_path)

--- a/R/icc.R
+++ b/R/icc.R
@@ -97,7 +97,7 @@ mysterycall_icc <- function(model_result,
 
   ci <- c(NA_real_, NA_real_)
   if (n_boot > 0L) {
-    if (!is.null(seed)) set.seed(seed)
+    if (!is.null(seed)) withr::local_seed(seed)
     ci <- .bootstrap_icc(model_result, is_nb, n_boot, conf_level)
   }
 

--- a/R/interaction_screen.R
+++ b/R/interaction_screen.R
@@ -119,7 +119,7 @@ mysterycall_interaction_screen <- function(
 
   # Cap at max_pairs
   if (length(pairs) > max_pairs) {
-    set.seed(42L)
+    withr::local_seed(42L)
     pairs <- pairs[sample(length(pairs), max_pairs)]
   }
 

--- a/R/internal_validation.R
+++ b/R/internal_validation.R
@@ -161,7 +161,7 @@ mysterycall_provider_split_simulation <- function(data, outcome, predictors, clu
   n_clusters <- length(clusters)
   
   # Assign clusters to folds
-  set.seed(42)
+  withr::local_seed(42)
   folds <- split(sample(clusters), rep(1:k, length.out = n_clusters))
   
   results <- data.frame()
@@ -176,7 +176,7 @@ mysterycall_provider_split_simulation <- function(data, outcome, predictors, clu
     glmmTMB::nbinom2()
   }
   
-  for (i in 1:k) {
+  for (i in seq_len(k)) {
     test_clusters <- folds[[i]]
     train_data <- data[!data[[cluster_col]] %in% test_clusters, ]
     test_data  <- data[data[[cluster_col]] %in% test_clusters, ]
@@ -244,7 +244,7 @@ mysterycall_bootstrap_predictor_stability <- function(data, outcome, predictors,
   cat("Running bootstrap predictor-retention stability loops...\n")
   pb <- utils::txtProgressBar(min = 0, max = n_boot, style = 3)
   
-  for (i in 1:n_boot) {
+  for (i in seq_len(n_boot)) {
     # Bootstrap resample
     boot_idx <- sample(1:n_obs, replace = TRUE)
     boot_data <- data[boot_idx, ]

--- a/R/lmm.R
+++ b/R/lmm.R
@@ -255,7 +255,7 @@ mysterycall_lmm <- function(data,
     function(pred) {
       x <- data_cc[[pred]]
       if (is.factor(x))    return(levels(x)[[1L]])
-      if (is.character(x)) return(sort(unique(x[!is.na(x)]))[[1L]])
+      if (is.character(x)) return(sort(unique(x[!is.na(x)]), method = "radix")[[1L]])
       NULL
     }
   ))
@@ -312,16 +312,19 @@ mysterycall_lmm <- function(data,
   # Column names differ between lmer and lmerTest::lmer
   est_col  <- "Estimate"
   se_col   <- "Std. Error"
-  t_col    <- if ("t value" %in% names(fe)) "t value" else "t value"
+  t_col    <- if ("t value" %in% names(fe)) "t value" else NULL
   df_col   <- if ("df" %in% names(fe)) "df" else NULL
   pval_col <- if ("Pr(>|t|)" %in% names(fe)) "Pr(>|t|)" else NULL
 
   p_values <- if (!is.null(pval_col)) {
     fe[[pval_col]]
-  } else {
+  } else if (!is.null(t_col)) {
     # Conservative fallback: t with residual df (est_df already counts intercept)
     df_resid <- nrow(data_cc) - est_df
     2 * stats::pt(abs(fe[[t_col]]), df = df_resid, lower.tail = FALSE)
+  } else {
+    # No t-statistic column either -> cannot derive p-values.
+    rep(NA_real_, nrow(fe))
   }
 
   df_values <- if (!is.null(df_col)) fe[[df_col]] else {

--- a/R/logistic_model.R
+++ b/R/logistic_model.R
@@ -174,7 +174,7 @@ mysterycall_logistic_model <- function(data,
     function(pred) {
       x <- data_cc[[pred]]
       if (is.factor(x))    return(levels(x)[[1L]])
-      if (is.character(x)) return(sort(unique(x[!is.na(x)]))[[1L]])
+      if (is.character(x)) return(sort(unique(x[!is.na(x)]), method = "radix")[[1L]])
       NULL
     }
   ))

--- a/R/manuscript_helpers.R
+++ b/R/manuscript_helpers.R
@@ -83,12 +83,20 @@ mysterycall_summarize_demographics <- function(data,
       mean(tolower(as.character(vals)) %in% c("female", "f"), na.rm = TRUE) * 100
     }
   } else {
+    if (!is.null(female_col)) {
+      warning(sprintf("Column '%s' not found in `data`; %% female set to NA.",
+                      female_col), call. = FALSE)
+    }
     NA_real_
   }
 
   pct_academic <- if (!is.null(setting_col) && setting_col %in% names(data)) {
     mean(data[[setting_col]] == academic_label, na.rm = TRUE) * 100
   } else {
+    if (!is.null(setting_col)) {
+      warning(sprintf("Column '%s' not found in `data`; %% academic set to NA.",
+                      setting_col), call. = FALSE)
+    }
     NA_real_
   }
 

--- a/R/marginal_power.R
+++ b/R/marginal_power.R
@@ -80,7 +80,7 @@ mysterycall_marginal_power <- function(n_subject, cell_means, sigma_subject, phi
                    pkg), call. = FALSE)
     }
   }
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) withr::local_seed(seed)
 
   cond2 <- condition_levels[2]
   int_term <- sprintf("condition%s:stratum", cond2)

--- a/R/matched_controls.R
+++ b/R/matched_controls.R
@@ -114,7 +114,7 @@ mysterycall_build_matched_controls <- function(
     units <- as.list(seq_len(nrow(treated)))
   }
 
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) withr::local_seed(seed)
   used <- character(0)
   rows <- list()
 

--- a/R/nb_model.R
+++ b/R/nb_model.R
@@ -188,7 +188,7 @@ mysterycall_nb_model <- function(data,
     function(pred) {
       x <- data_cc[[pred]]
       if (is.factor(x))    return(levels(x)[[1L]])
-      if (is.character(x)) return(sort(unique(x[!is.na(x)]))[[1L]])
+      if (is.character(x)) return(sort(unique(x[!is.na(x)]), method = "radix")[[1L]])
       NULL
     }
   ))

--- a/R/nb_power.R
+++ b/R/nb_power.R
@@ -82,7 +82,7 @@ mysterycall_nb_power <- function(n_physicians,
   calls_per_physician <- as.integer(calls_per_physician)
   n_sim               <- as.integer(n_sim)
 
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) withr::local_seed(seed)
 
   log_baseline  <- log(baseline_mean)
   log_irr       <- log(irr)

--- a/R/poisson_model.R
+++ b/R/poisson_model.R
@@ -213,7 +213,7 @@ mysterycall_poisson_model <- function(data,
     function(pred) {
       x <- data_cc[[pred]]
       if (is.factor(x))    return(levels(x)[[1L]])
-      if (is.character(x)) return(sort(unique(x[!is.na(x)]))[[1L]])
+      if (is.character(x)) return(sort(unique(x[!is.na(x)]), method = "radix")[[1L]])
       NULL
     }
   ))

--- a/R/spatial_density.R
+++ b/R/spatial_density.R
@@ -115,7 +115,7 @@ mysterycall_calculate_hq_distance <- function(lats, lons, platforms, matched_pai
     }
   }
   
-  for (i in 1:n) {
+  for (i in seq_len(n)) {
     lat <- lats[i]
     lon <- lons[i]
     plat <- platforms[i]

--- a/R/splitting_dataframe_to_send_to_callers.R
+++ b/R/splitting_dataframe_to_send_to_callers.R
@@ -160,7 +160,7 @@ mysterycall_split_and_save <- function(data_or_path, output_directory, lab_assis
   # Shuffle rows within each insurance group (seed-controlled), then assign
   # lab assistants via round-robin so every assistant receives at most one row
   # more than any other  --  guaranteed regardless of group size or roster length.
-  set.seed(seed)
+  withr::local_seed(seed)
   if (nrow(data) == 0) {
     message("Input contains zero rows; workbooks will be created without assignments.")
     data <- data %>%

--- a/R/twopart_power.R
+++ b/R/twopart_power.R
@@ -59,7 +59,7 @@ mysterycall_twopart_power <- function(n_total, offer_ref, offer_trt,
     stop("mysterycall_twopart_power() needs the MASS package (in Suggests).",
          call. = FALSE)
   }
-  if (!is.null(seed)) set.seed(seed)
+  if (!is.null(seed)) withr::local_seed(seed)
 
   rows <- lapply(n_total, function(nt) {
     .mc_twopart_at_n(nt, offer_ref, offer_trt, wait_ref, wait_trt, phi,

--- a/R/wait_time_by_group.R
+++ b/R/wait_time_by_group.R
@@ -63,6 +63,7 @@ mysterycall_wait_time_by_group <- function(
   checkmate::assert_string(outcome_col)
   checkmate::assert_string(group_col)
   checkmate::assert_names(names(data), must.include = c(outcome_col, group_col))
+  checkmate::assert_numeric(data[[outcome_col]], .var.name = outcome_col)
   checkmate::assert_integerish(digits_median, lower = 0, len = 1)
   checkmate::assert_integerish(digits_q,      lower = 0, len = 1)
   checkmate::assert_flag(filter_positive)


### PR DESCRIPTION
## Summary

Defensive hardening across the package, from a read-only survey. Three tracks, each finding verified against source before touching it (a couple of survey-flagged items turned out to be already-handled and were correctly skipped). No happy-path behavior changes — reproducibility for a given seed is preserved, and in CI's locale the sort/reference-level output is unchanged.

## Changes

**RNG stream hygiene** — 11 functions that set a random seed *internally* now use `withr::local_seed()` instead of `set.seed()`, so they no longer clobber the **caller's global RNG stream** as a side effect (a user's own `sample()` after calling one of these used to silently change). Reproducible for a given seed as before. `mysterycall_clean_phase1()` was already correct (manual `.Random.seed` save/restore) and is left untouched.
- `mysterycall_nb_power()`, `mysterycall_marginal_power()`, `mysterycall_adjusted_power()`, `mysterycall_twopart_power()`, `mysterycall_icc()`, `mysterycall_bootstrap_ci()`, `mysterycall_build_matched_controls()`, `mysterycall_split_and_save()`, `mysterycall_stratified_sample()`, and the internal validation / interaction-screen helpers.

**Locale-independent reproducibility**
- The reference-category pick in `nb_model`/`poisson_model`/`logistic_model`/`lmm`, and the audit-artifact key ordering shared by `clean_phase1` (writer) and `verify_artifact` (reader), now sort with `method = "radix"`. Removes an `LC_COLLATE` dependence that could otherwise change the model baseline level or the provenance hash across machines/locales. (Both hash sorts changed together so writer/verifier stay consistent; keys are lowercase ASCII, so the hash is unchanged in practice.)
- `for (i in 1:n)` → `seq_len(n)` in the validation / spatial-density loops (correct behavior when a count is 0).
- `mysterycall_lmm()`: a dead `if … else "t value"` branch → `else NULL` plus a downstream guard that returns `NA` p-values rather than erroring if a model summary lacks the t-statistic column.

**Guards & silent-skip fixes**
- `mysterycall_summarize_demographics()` now **warns** when a *supplied* `female_col` / `setting_col` is not in the data (previously a silent `NA`, indistinguishable from "not requested").
- `mysterycall_wait_time_by_group()` asserts the outcome column is numeric before computing medians/quantiles.
- `mysterycall_clean_phase1()` and `mysterycall_verify_artifact()` add `digest` (and `jsonlite`) to their up-front `requireNamespace()` guards — used unconditionally to build the provenance hash, so a missing package now gives the friendly install message instead of a cryptic mid-run error.
- `mysterycall_export_results_docx()` creates the target directory if missing, matching the package's other writers.

**Verified already-handled (skipped, no change):** `prepare_calls` (the call-date column is already required and a missing appointment-date column is already warned), and `clean_phase1`'s RNG (already save/restores `.Random.seed`).

## Checklist

- [ ] `devtools::check()` 0/0 — **not run here (no R runtime); CI is the gate.**
- [x] `NEWS.md` updated
- [x] No public API/signature changes; `withr` already in Imports
- [ ] Behaviour covered by tests — relies on existing tests staying green (these are defensive additions); new assertions/warnings are narrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYF26RbcWj3dJU4MojYFX)_