### PR TITLE
Test honesty + minor robustness polish

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Robustness / hardening
 
+- `mysterycall_insurance_wait_sentence()` now derives the direction word from the
+  *displayed* rounded percentage: a difference that rounds to `0%` reads
+  "similar" instead of "0% longer/shorter" (previously the word came from the
+  unrounded IRR).
+
 - **RNG side-effects removed.** Eleven functions that set a random seed
   internally (`mysterycall_nb_power()`, `mysterycall_marginal_power()`,
   `mysterycall_adjusted_power()`, `mysterycall_twopart_power()`,

--- a/R/compare_waves.R
+++ b/R/compare_waves.R
@@ -95,6 +95,10 @@ mysterycall_compare_waves <- function(
   }
 
   # ---- Wilson CI for a proportion ---------------------------------------------
+  # NOTE: intentionally a LOCAL helper, distinct from the package-level
+  # .wilson_ci() in outcome_analysis.R (signature (k, n, conf_level), returns an
+  # unnamed pair). This one is (x, n, alpha) and returns a named c(lower, upper).
+  # Do not "DRY-merge" the two -- the signatures and return shapes differ.
   .wilson_ci <- function(x, n, alpha = 0.05) {
     if (n == 0) return(c(lower = NA_real_, upper = NA_real_))
     z    <- stats::qnorm(1 - alpha / 2)

--- a/R/insurance_wait_sentence.R
+++ b/R/insurance_wait_sentence.R
@@ -148,8 +148,9 @@ mysterycall_insurance_wait_sentence <- function(
 
   # 4. Percentage difference
   pct_diff  <- round((irr - 1) * 100, digits = digits_pct)
-  # Handle the exact-tie case: irr == 1 is "similar", not "shorter".
-  direction <- if (irr > 1) "longer" else if (irr < 1) "shorter" else "similar"
+  # Base the direction word on the *displayed* percentage so a difference that
+  # rounds to 0% reads "similar", never "0% longer/shorter".
+  direction <- if (pct_diff > 0) "longer" else if (pct_diff < 0) "shorter" else "similar"
 
   # 5. Build sentence
   p_fmt <- if (p_value < 0.001) "< 0.001" else sprintf("%.*f", 3L, p_value)

--- a/tests/testthat/test-cov-medicaid_expansion.R
+++ b/tests/testthat/test-cov-medicaid_expansion.R
@@ -1,16 +1,12 @@
 library(testthat)
 library(mysterycall)
 
-# mysterycall_medicaid_expansion_status is not yet implemented as a function.
-# R/medicaid_expansion.R is a data-documentation file for the `medicaid_expansion`
-# dataset; the lookup function does not exist in the current package.
-# All tests here skip until the function is added.
+# R/medicaid_expansion.R documents the `medicaid_expansion` dataset; there is no
+# `mysterycall_medicaid_expansion_status()` lookup function in the package yet.
+# This file covers the dataset itself. (The former always-skip placeholder for
+# the not-yet-existent function was removed -- it asserted nothing.)
 
 test_that("medicaid_expansion dataset exists and has expected structure", {
   expect_true(exists("medicaid_expansion", envir = asNamespace("mysterycall")) ||
               "medicaid_expansion" %in% ls(asNamespace("mysterycall")))
-})
-
-test_that("medicaid_expansion_status function tests (skipped - not yet implemented)", {
-  skip("mysterycall_medicaid_expansion_status() is not yet implemented")
 })

--- a/tests/testthat/test-facet-histogram.R
+++ b/tests/testthat/test-facet-histogram.R
@@ -1,7 +1,3 @@
-test_that("facet_histogram tests require ggplot2", {
-  skip_if_not_installed("ggplot2")
-})
-
 # Helper
 make_hist_df <- function(n = 120, seed = 42) {
   set.seed(seed)

--- a/tests/testthat/test-log-histogram.R
+++ b/tests/testthat/test-log-histogram.R
@@ -1,7 +1,3 @@
-test_that("log_histogram tests require ggplot2", {
-  skip_if_not_installed("ggplot2")
-})
-
 # Helper
 make_log_df <- function(n = 100, seed = 99) {
   set.seed(seed)

--- a/tests/testthat/test-logging-system.R
+++ b/tests/testthat/test-logging-system.R
@@ -339,16 +339,18 @@ test_that("Logging handles errors gracefully", {
 })
 
 test_that("Nested logging works correctly", {
-  mysterycall:::mysterycall_workflow_start("Outer Workflow", total_steps = 2)
+  expect_no_error(suppressMessages({
+    mysterycall:::mysterycall_workflow_start("Outer Workflow", total_steps = 2)
 
-  mysterycall:::mysterycall_log_step("Outer Step 1")
-  mysterycall:::mysterycall_log_info("Starting inner operations")
-  mysterycall:::mysterycall_log_info("Inner operation 1")
-  mysterycall:::mysterycall_log_info("Inner operation 2")
-  mysterycall:::mysterycall_log_success("Inner operations complete")
-  mysterycall:::mysterycall_log_step_complete()
+    mysterycall:::mysterycall_log_step("Outer Step 1")
+    mysterycall:::mysterycall_log_info("Starting inner operations")
+    mysterycall:::mysterycall_log_info("Inner operation 1")
+    mysterycall:::mysterycall_log_info("Inner operation 2")
+    mysterycall:::mysterycall_log_success("Inner operations complete")
+    mysterycall:::mysterycall_log_step_complete()
 
-  mysterycall:::mysterycall_workflow_end()
+    mysterycall:::mysterycall_workflow_end()
+  }))
 })
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

Small tidy-up PR: makes three tests that asserted nothing either assert or go away, plus two low-risk robustness touches. No public API changes.

## Changes

**Test honesty**
- `test-logging-system.R` — "Nested logging works correctly" exercised 7 logging functions but made **no assertion** (only implicitly "doesn't error"). Now wraps the sequence in `expect_no_error(suppressMessages(...))`.
- `test-facet-histogram.R` / `test-log-histogram.R` — removed the opening `test_that("… require ggplot2", { skip_if_not_installed })` blocks that asserted nothing and always "passed." The real tests below each already guard themselves with `skip_if_not_installed("ggplot2")` (18 / 17 of them), and the first real test in each is a genuine error assertion.
- `test-cov-medicaid_expansion.R` — removed the always-`skip()` placeholder for the non-existent `mysterycall_medicaid_expansion_status()` and corrected the stale "all tests here skip" header. The real dataset-structure assertion remains.

**Minor robustness**
- `mysterycall_insurance_wait_sentence()` — the direction word ("longer"/"shorter"/"similar") now derives from the **displayed** rounded `pct_diff`, so a difference that rounds to `0%` reads "similar" instead of "0% longer". No change for clear differences — for any non-zero rounded difference `sign(irr - 1) == sign(pct_diff)`, so the snapshot (`… 2% longer …`, IRR 1.02) and the `longer`/`shorter` tests are unaffected.
- `mysterycall_compare_waves()` — added a comment documenting that its local `.wilson_ci()` is intentionally distinct from the package-level `.wilson_ci()` in `outcome_analysis.R` (different signature and return shape), so a future "DRY cleanup" doesn't silently merge them.

## Checklist

- [ ] `devtools::check()` 0/0 — **not run here (no R runtime); CI is the gate.**
- [x] `NEWS.md` updated (the user-facing sentence tweak)
- [x] No public API/signature changes
- [x] Behaviour covered by tests — the touched tests now assert; the sentence change is covered by existing `insurance_wait_sentence` tests + snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYF26RbcWj3dJU4MojYFX)_