### PR TITLE
docs: ARCHITECTURE.md contributor guide + orchestrator cross-links

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -64,3 +64,4 @@
 ^check_docs\.R$
 ^check_internal\.R$
 ^roxygen_tags_summary\.txt$
+^ARCHITECTURE\.md$

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,171 @@
+# Architecture & Codebase Orientation
+
+A map of the **mysterycall** codebase for people who need to *read, navigate, and
+extend the code* — not just call it. If you only want to use the package, start
+with the README and the pkgdown site. If you're about to open a PR, read this
+first, then [`CONTRIBUTING.md`](CONTRIBUTING.md) for the mechanics.
+
+---
+
+## 1. What the package does
+
+`mysterycall` provides the common functions for **mystery-caller / audit studies**
+that measure patient access to care — studies where trained callers contact
+provider offices under different insurance scenarios (e.g. Medicaid vs. a
+commercial plan) and record whether an appointment was offered and how long the
+wait was. The package covers the whole arc:
+
+1. **Build the provider roster** — NPI/taxonomy search, address normalization,
+   academic classification, census/geography enrichment.
+2. **Clean and validate the call log** — one row per call, with an insurance arm
+   and recorded outcomes.
+3. **Analyze** — acceptance-rate disparities and wait-time models (Poisson / NB /
+   logistic / linear mixed models), with the appropriate clustering and CIs.
+4. **Report** — publication-ready tables, STROBE flow diagrams, and prose
+   "results-section" sentences, plus a verifiable provenance trail.
+
+## 2. The big picture: a two-phase pipeline
+
+Almost everything hangs off two orchestrator functions. Read these two files
+first — they are the spine of the package and name the subsystems they call:
+
+| Phase | Orchestrator | File | What it does |
+|-------|--------------|------|--------------|
+| **Collection / cleaning** | `mysterycall_run_workflow()` | `R/run_mystery_caller_workflow.R` | Roster → validated, de-duplicated, standardized call data (phases 1 & 2). |
+| **Analysis** | `mysterycall_run_analysis()` | `R/run_analysis.R` | A cleaned call log → QC, dedup, demographics, acceptance rates, wait-time models, sensitivity analyses. Runs as a sequence of named, individually-skippable **steps**. |
+
+```
+  roster building            call cleaning                 analysis
+ (NPI / taxonomy /   →   run_workflow()   →   run_analysis(steps = c("qc","dedup",
+  census / academic)      (phase 1 + 2)         "clean_medicaid","demographics",
+                                                "scenarios","acceptance_rates",
+                                                "wait_times","poisson","sensitivity"))
+                                                        │
+                                                        ▼
+                                       tables · STROBE flow · results paragraphs · audit trail
+```
+
+`run_analysis()` is a good model of the house style: upfront `checkmate`
+validation, an internal `.try()` wrapper so one failing step doesn't sink the
+run, and a per-step `if (col %in% names(data))` guard. See §6 for the
+column-name contract that ties the two phases together.
+
+## 3. Repository layout
+
+```
+R/                one file per function (or a small tight cluster); ~260 files
+man/              hand-written .Rd — CHECKED IN, see §5. ~600 topics
+tests/testthat/   test-<name>.R mirrors R/<name>.R; testthat edition 3, parallel
+vignettes/        23 task-oriented articles (getting started, workflow, models, …)
+data/ + data-raw/ bundled datasets (e.g. city_state_to_lat_long) and their builders
+inst/extdata/     shapefiles and fixtures
+_pkgdown.yml      the reference index — every exported function is filed here
+NEWS.md           user-facing changelog under the current dev version
+```
+
+## 4. Subsystem map
+
+The `@family` tag on each function is the authoritative grouping (and drives the
+pkgdown reference sections). The major families, largest first:
+
+- **outcomes** — the analytic core: acceptance rates, wait-time models
+  (`poisson_model`, `nb_model`, `logistic_model`, `lmm`), IRR/GMR helpers, and
+  the power-analysis simulators (`nb_power`, `marginal_power`, …).
+- **provider / npi / census / address-normalization / academic-indicators** —
+  everything that turns a specialty + geography into a validated provider roster.
+- **data / data-preparation / data-quality / quality / validation / safe-joins** —
+  cleaning, de-duplication, flagging, and joins that refuse to silently drop rows.
+- **manuscript / reporting / table / green-journal-\*** — publication output:
+  `results_paragraph`, Table 1, disparities tables, docx/flextable export, STROBE
+  flow, and the "Green Journal" (Obstetrics & Gynecology) themed figures.
+- **workflow / logging / progress / utilities** — orchestration and cross-cutting
+  helpers (structured logging, progress spinners, small utilities).
+
+When adding a function, pick the family it belongs to and file it in the matching
+`_pkgdown.yml` section.
+
+## 5. The documentation model (read this before touching any `R/` doc)
+
+**Roxygen comments live in `R/`, but the generated `man/*.Rd` files are checked
+into the repo and must stay in sync.** The canonical workflow is:
+
+```r
+devtools::document()   # regenerates man/*.Rd and NAMESPACE from the @ tags
+```
+
+Consequences for contributors:
+
+- **Always run `document()` after editing any `#'` block or a function
+  signature.** CI does not run it for you; a drifted `.Rd` is a real
+  `R CMD check` WARNING (codoc / undocumented-arguments).
+- **`@family` is bidirectional.** Adding `@family outcomes` to a function makes
+  roxygen rewrite the "Other outcomes:" cross-reference in *every* other
+  outcomes `.Rd`. Never hand-edit those lists — regenerate.
+- **Internal helpers use `@noRd`** (no man page) — most are named with a leading
+  dot (`.mc_*`, `.fmt_*`). Exported functions are `mysterycall_*` and carry
+  `@param`, `@return`, and at least one `@examples`.
+- Examples that need a network/API or a heavy optional package are wrapped in
+  `\dontrun{}` / `@examplesIf requireNamespace(...)`.
+
+## 6. Conventions worth knowing
+
+These are the non-obvious, project-specific rules — the things a newcomer trips on:
+
+- **Naming.** Exported = `mysterycall_<verb>()`. Internal = dotted (`.mc_format_p`,
+  `.wilson_ci`). Deprecated shims live in `R/deprecated.R`.
+- **Input validation.** Prefer `checkmate::assert_*`; where `stopifnot()` is used
+  it carries a *named* message: `stopifnot("`data` must be a data frame" = is.data.frame(data))`.
+- **Optional dependencies.** Anything in `Suggests` (ggplot2, survival, lme4,
+  glmmTMB, mice, sf, tidycensus, gt, …) is guarded with
+  `requireNamespace("pkg", quietly = TRUE)` before first use — never `library()`
+  inside a function.
+- **RNG hygiene.** Functions that need a seed use `withr::local_seed(seed)`, not
+  `set.seed()`, so they don't clobber the caller's global random stream.
+- **Locale-independent reproducibility.** Sorts whose result affects output —
+  a model's reference level, a provenance hash's key order — use
+  `sort(..., method = "radix")` so they don't depend on `LC_COLLATE`.
+- **The phase-2 column contract.** `run_workflow()` renames incoming columns to
+  short "standard" names (`reason_for_exclusions` → `exclusion_reasons`).
+  `run_analysis()` documents the *long* names as defaults but tolerates the short
+  aliases via `.mc_resolve_col()` — so the two chain cleanly. If you add a column
+  parameter that both touch, wire it through that helper.
+- **P-values.** `.mc_format_p()` (in `R/format_pvalue.R`) is the single source of
+  truth for p-value strings in tables (`"< 0.001"` / `"0.043"`). Manuscript prose
+  uses the spaced `"p < 0.001"` / `"p = 0.043"` convention.
+- **Wait-time outcome.** The canonical wait-time column is
+  `business_days_until_appointment`; `calendar_days` is a documented *secondary*
+  column for calendar-vs-business sensitivity.
+
+## 7. Testing conventions
+
+- `test-<name>.R` mirrors `R/<name>.R`; `testthat` edition 3, run in parallel
+  (`Config/testthat/parallel: true`).
+- Label pattern: `test_that("fn: case → expected", ...)`.
+- Guard tests needing a `Suggests` package with `skip_if_not_installed("pkg")`.
+- Every `test_that` must actually assert — no empty "doesn't error" blocks; use
+  `expect_no_error()` if that really is the assertion.
+- Do **not** use `skip_on_cran()` to hide a failing test.
+
+## 8. Adding a new function, end to end
+
+1. Create `R/<name>.R`. Add roxygen: `@family <group>`, `@param`, `@return`,
+   `@seealso` to the related functions, and at least one `@examples`.
+2. `devtools::document()` to generate `man/<name>.Rd` and update `NAMESPACE`.
+3. File the function in the right `_pkgdown.yml` reference section.
+4. Add `tests/testthat/test-<name>.R` — happy path + `NA`/empty input.
+5. Add a `NEWS.md` bullet under the current dev version.
+6. `devtools::check()` → 0 errors / 0 warnings.
+
+## 9. Where to start reading
+
+- **The analysis spine:** `R/run_analysis.R` — shows the step model, validation,
+  and how the outcome subsystems are called.
+- **A model, end to end:** `R/poisson_model.R` (or `R/lmm.R`) — fitting, the
+  reference-level pick, IRR/GMR tables, and the `print()` method.
+- **Reporting:** `R/results_paragraph.R` — how model output becomes a sentence.
+- **Provenance:** `R/clean_phase_1_results.R` (writer) and `R/audit-verify.R`
+  (reader) — the audit-trail hash and its verification.
+- **Collection:** `R/run_mystery_caller_workflow.R` — the phase-1/phase-2 flow.
+
+Questions that aren't answered here belong in a
+[GitHub Discussion](https://github.com/mufflyt/mysterycall/discussions).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,12 @@
 Thank you for considering contributing to **mysterycall**! This guide explains how
 to report bugs, propose features, and submit pull requests.
 
+> **New to the codebase?** Read [ARCHITECTURE.md](ARCHITECTURE.md) first — it
+> maps the two-phase collection → analysis pipeline, the subsystem families, the
+> documentation model (`.Rd` files are checked in — run `devtools::document()`),
+> and the project-specific conventions. This guide covers the *process*;
+> `ARCHITECTURE.md` covers the *mental model*.
+
 ## Code of Conduct
 
 All interactions are governed by our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # mysterycall 1.6.3.9000 (development version)
 
+## Documentation
+
+- Added `ARCHITECTURE.md`, a codebase-orientation guide for contributors: the
+  two-phase collection → analysis pipeline, the subsystem `@family` map, the
+  documentation model (hand-checked-in `.Rd` + `devtools::document()`), the
+  project-specific conventions (validation, optional-dependency guards, RNG
+  hygiene, the phase-2 column contract), and where to start reading. Linked from
+  the README and `CONTRIBUTING.md`.
+- `mysterycall_run_analysis()` and `mysterycall_run_workflow()` now cross-link
+  each other via `@seealso`, so the collection and analysis halves of the
+  pipeline are discoverable from either help page.
+- Documented the return value of `print.mysterycall_screen_predictors()`.
+
 ## Robustness / hardening
 
 - `mysterycall_insurance_wait_sentence()` now derives the direction word from the

--- a/R/run_analysis.R
+++ b/R/run_analysis.R
@@ -78,6 +78,8 @@
 #'     encountered an error or had missing required columns.}
 #' }
 #'
+#' @seealso [mysterycall_run_workflow()] builds and cleans the call log this
+#'   analyzes; together they form the collection -> analysis pipeline.
 #' @family workflow helpers
 #' @importFrom checkmate assert_data_frame assert_flag assert_character
 #' @export

--- a/R/run_mystery_caller_workflow.R
+++ b/R/run_mystery_caller_workflow.R
@@ -93,6 +93,8 @@
 #'   [mysterycall_clean_phase2()].
 #'   Run [mysterycall_preflight_check()] before starting to catch missing
 #'   API keys and malformed inputs early.
+#'   Feed the cleaned result into [mysterycall_run_analysis()] for the
+#'   analysis phase.
 #' @family workflow
 #' @examplesIf interactive()
 #' results <- mysterycall_run_workflow(

--- a/R/screen_predictors.R
+++ b/R/screen_predictors.R
@@ -508,6 +508,7 @@ mysterycall_screen_predictors <- function(data,
 #' @param x A `mysterycall_screen_predictors` object.
 #' @param n Integer. Number of rows to print. Default `10L`.
 #' @param ... Ignored.
+#' @return The input `x`, invisibly.
 #' @export
 #' @keywords internal
 print.mysterycall_screen_predictors <- function(x, n = 10L, ...) {

--- a/README.md
+++ b/README.md
@@ -342,7 +342,10 @@ citation("mysterycall")
 
 ## Contributing
 
-Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for
+Contributions are welcome. New to the codebase? Start with
+[ARCHITECTURE.md](ARCHITECTURE.md) — a map of how the package is organized (the
+two-phase collection → analysis pipeline, the subsystem families, and the
+project-specific conventions). Then read [CONTRIBUTING.md](CONTRIBUTING.md) for
 the development workflow, coding style, and pull-request process. Bug reports
 and feature requests are best filed as
 [GitHub issues](https://github.com/mufflyt/mysterycall/issues).

--- a/man/mysterycall_run_analysis.Rd
+++ b/man/mysterycall_run_analysis.Rd
@@ -116,6 +116,11 @@ and a sensitivity analysis into a single reproducible call.  Each step is
 wrapped in error handling so that a failure in one step does not abort the
 rest of the pipeline.
 }
+\seealso{
+\code{\link[=mysterycall_run_workflow]{mysterycall_run_workflow()}} builds and
+cleans the call log this analyzes; together they form the
+collection -> analysis pipeline.
+}
 \examples{
 \dontrun{
 set.seed(1)

--- a/man/mysterycall_run_workflow.Rd
+++ b/man/mysterycall_run_workflow.Rd
@@ -171,8 +171,9 @@ Stage functions called by this workflow:
 \code{\link[=mysterycall_clean_phase2]{mysterycall_clean_phase2()}}.
 Run \code{\link[=mysterycall_preflight_check]{mysterycall_preflight_check()}} before starting to catch missing
 API keys and malformed inputs early.
+Feed the cleaned result into \code{\link[=mysterycall_run_analysis]{mysterycall_run_analysis()}} for the analysis phase.
 
-Other workflow: 
+Other workflow:
 \code{\link{mysterycall_call_productivity}()},
 \code{\link{mysterycall_clean_phase1}()},
 \code{\link{mysterycall_clean_phase2}()},

--- a/man/print.mysterycall_screen_predictors.Rd
+++ b/man/print.mysterycall_screen_predictors.Rd
@@ -13,6 +13,9 @@
 
 \item{...}{Ignored.}
 }
+\value{
+The input \code{x}, invisibly.
+}
 \description{
 Print a mysterycall_screen_predictors result
 }


### PR DESCRIPTION
## Summary

Documentation aimed at **newcomers to the code** (contributors), not end users. The package is already well-documented for users (23 vignettes, a full README, high roxygen coverage), so the real gap was a **codebase mental-model** — plus a couple of genuine roxygen tag gaps.

## Changes

**`ARCHITECTURE.md` (new) — the flagship**
A contributor orientation guide:
- What the package does and the **two-phase pipeline** (`run_workflow()` → `run_analysis()`) with a data-flow sketch.
- Repository layout and the **subsystem `@family` map** (outcomes, provider/npi/census, data-quality, manuscript/reporting, workflow/logging…).
- **The documentation model** — roxygen in `R/` but `.Rd` are checked in; run `devtools::document()`; why `@family` must be regenerated, not hand-edited; `@noRd` for internals.
- **Project-specific conventions** newcomers trip on: `checkmate`/named-`stopifnot` validation, `requireNamespace` guards for `Suggests`, `withr::local_seed` RNG hygiene, `sort(method="radix")` for locale-independence, the phase-2 column contract via `.mc_resolve_col()`, `.mc_format_p()` p-values, business-vs-calendar days.
- Testing conventions, how to add a function end-to-end, and **where to start reading**.

Linked from the README ("Contributing") and `CONTRIBUTING.md` (which covers *process*; ARCHITECTURE covers the *mental model*). Added to `.Rbuildignore`.

**Roxygen tags (source + hand-checked-in `.Rd`, kept in sync)**
- `mysterycall_run_analysis()` ↔ `mysterycall_run_workflow()` now `@seealso` each other — the collection and analysis halves of the pipeline are now discoverable from either help page.
- Documented the `@return` of `print.mysterycall_screen_predictors()` (the one exported topic that had an `.Rd` but no `\value`).

**On the larger tag "gaps":** a naive scan flags ~90 functions "missing `@family`" and ~170 "missing `@seealso`", but the bulk are **undocumented S3 methods** (no man page) or **`@rdname`-shared pages** that already inherit their docs. Adding `@family` at scale rewrites bidirectional cross-references across many `.Rd`, which is only safe via a `devtools::document()` pass — flagged as R-runtime follow-up rather than risk hand-editing dozens of `.Rd`.

## Checklist

- [ ] `devtools::check()` 0/0 — **not run here (no R runtime); CI is the gate.**
- [x] `NEWS.md` updated
- [x] `.Rd` kept in sync with roxygen by hand (brace-balanced; `\link` format matches existing)
- [x] No code or public API changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYF26RbcWj3dJU4MojYFX)_